### PR TITLE
[codex] Add Postgres schema models

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ Inspect resolved non-secret settings:
 ```bash
 linkedin-scrapper config
 ```
+
+Create the database schema:
+
+```bash
+linkedin-scrapper init-db
+```

--- a/src/linkedin_scrapper/cli.py
+++ b/src/linkedin_scrapper/cli.py
@@ -5,6 +5,7 @@ from rich.console import Console
 
 from linkedin_scrapper.config import Settings
 from linkedin_scrapper.pipeline import PipelineRequest, build_pipeline
+from linkedin_scrapper.services.database import build_engine, drop_db, init_db
 
 app = typer.Typer(help="LinkedIn job matching POC backend.")
 console = Console()
@@ -15,6 +16,27 @@ def show_config() -> None:
     """Show resolved non-secret configuration."""
     settings = Settings()
     console.print(settings.safe_dump())
+
+
+@app.command("init-db")
+def initialize_database(
+    drop_existing: bool = typer.Option(
+        False,
+        "--drop-existing",
+        help="Drop existing POC tables before creating the schema.",
+    ),
+) -> None:
+    """Create the database schema from SQLAlchemy metadata."""
+    settings = Settings()
+    if not settings.database_url:
+        console.print({"missing_required_environment": ["DATABASE_URL"]})
+        raise typer.Exit(code=1)
+
+    engine = build_engine(settings)
+    if drop_existing:
+        drop_db(engine)
+    init_db(engine)
+    console.print({"database_initialized": True, "drop_existing": drop_existing})
 
 
 @app.command("run-pipeline")

--- a/src/linkedin_scrapper/models.py
+++ b/src/linkedin_scrapper/models.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    Uuid,
+    func,
+)
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.types import JSON
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class SearchRunStatus(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class ApplicationStatus(StrEnum):
+    NEW = "new"
+    SHORTLISTED = "shortlisted"
+    APPLIED = "applied"
+    REJECTED = "rejected"
+    IGNORED = "ignored"
+
+
+class TimestampMixin:
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+class CandidateProfile(TimestampMixin, Base):
+    __tablename__ = "candidate_profiles"
+
+    id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid4)
+    cv_text: Mapped[str] = mapped_column(Text, nullable=False)
+    target_roles: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    skills: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    locations: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    remote_preference: Mapped[str | None] = mapped_column(String(50))
+    seniority: Mapped[str | None] = mapped_column(String(100))
+    exclusions: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    profile_payload: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
+
+    search_runs: Mapped[list[SearchRun]] = relationship(
+        back_populates="candidate_profile",
+        cascade="all, delete-orphan",
+    )
+
+
+class SearchRun(TimestampMixin, Base):
+    __tablename__ = "search_runs"
+    __table_args__ = (
+        CheckConstraint(
+            "status in ('pending', 'running', 'succeeded', 'failed')",
+            name="ck_search_runs_status",
+        ),
+        Index("ix_search_runs_profile_status", "profile_id", "status"),
+    )
+
+    id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid4)
+    profile_id: Mapped[UUID] = mapped_column(
+        ForeignKey("candidate_profiles.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    query: Mapped[str] = mapped_column(String(255), nullable=False)
+    linkedin_url: Mapped[str] = mapped_column(Text, nullable=False)
+    actor_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(30),
+        default=SearchRunStatus.PENDING.value,
+        nullable=False,
+    )
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    error_message: Mapped[str | None] = mapped_column(Text)
+
+    candidate_profile: Mapped[CandidateProfile] = relationship(back_populates="search_runs")
+    job_links: Mapped[list[SearchRunJob]] = relationship(
+        back_populates="search_run",
+        cascade="all, delete-orphan",
+    )
+
+
+class Job(TimestampMixin, Base):
+    __tablename__ = "jobs"
+    __table_args__ = (
+        UniqueConstraint("external_id", name="uq_jobs_external_id"),
+        UniqueConstraint("url", name="uq_jobs_url"),
+        Index("ix_jobs_company", "company"),
+        Index("ix_jobs_location", "location"),
+    )
+
+    id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid4)
+    external_id: Mapped[str | None] = mapped_column(String(255))
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    company: Mapped[str | None] = mapped_column(String(255))
+    location: Mapped[str | None] = mapped_column(String(255))
+    url: Mapped[str] = mapped_column(Text, nullable=False)
+    apply_url: Mapped[str | None] = mapped_column(Text)
+    description: Mapped[str | None] = mapped_column(Text)
+    salary: Mapped[str | None] = mapped_column(String(255))
+    remote: Mapped[bool | None]
+    posted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    raw_payload: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
+
+    score: Mapped[JobScore | None] = relationship(
+        back_populates="job",
+        cascade="all, delete-orphan",
+    )
+    application: Mapped[Application | None] = relationship(
+        back_populates="job",
+        cascade="all, delete-orphan",
+    )
+    search_run_links: Mapped[list[SearchRunJob]] = relationship(
+        back_populates="job",
+        cascade="all, delete-orphan",
+    )
+
+
+class SearchRunJob(Base):
+    __tablename__ = "search_run_jobs"
+
+    search_run_id: Mapped[UUID] = mapped_column(
+        ForeignKey("search_runs.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    job_id: Mapped[UUID] = mapped_column(
+        ForeignKey("jobs.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    first_seen_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    search_run: Mapped[SearchRun] = relationship(back_populates="job_links")
+    job: Mapped[Job] = relationship(back_populates="search_run_links")
+
+
+class JobScore(TimestampMixin, Base):
+    __tablename__ = "job_scores"
+    __table_args__ = (
+        CheckConstraint("score >= 0 and score <= 100", name="ck_job_scores_score_range"),
+        UniqueConstraint("job_id", name="uq_job_scores_job_id"),
+        Index("ix_job_scores_score", "score"),
+    )
+
+    id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid4)
+    job_id: Mapped[UUID] = mapped_column(
+        ForeignKey("jobs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    score: Mapped[int] = mapped_column(Integer, nullable=False)
+    summary: Mapped[str | None] = mapped_column(Text)
+    match_reasons: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    missing_skills: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    risk_flags: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    scoring_payload: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
+
+    job: Mapped[Job] = relationship(back_populates="score")
+
+
+class Application(TimestampMixin, Base):
+    __tablename__ = "applications"
+    __table_args__ = (
+        CheckConstraint(
+            "status in ('new', 'shortlisted', 'applied', 'rejected', 'ignored')",
+            name="ck_applications_status",
+        ),
+        UniqueConstraint("job_id", name="uq_applications_job_id"),
+        Index("ix_applications_status", "status"),
+    )
+
+    id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid4)
+    job_id: Mapped[UUID] = mapped_column(
+        ForeignKey("jobs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    status: Mapped[str] = mapped_column(
+        String(30),
+        default=ApplicationStatus.NEW.value,
+        nullable=False,
+    )
+    notes: Mapped[str | None] = mapped_column(Text)
+    applied_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    job: Mapped[Job] = relationship(back_populates="application")

--- a/src/linkedin_scrapper/services/database.py
+++ b/src/linkedin_scrapper/services/database.py
@@ -2,6 +2,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 
 from linkedin_scrapper.config import Settings
+from linkedin_scrapper.models import Base
 
 
 def build_engine(settings: Settings) -> Engine:
@@ -9,3 +10,11 @@ def build_engine(settings: Settings) -> Engine:
         raise RuntimeError("DATABASE_URL is required to build the database engine.")
 
     return create_engine(settings.database_url)
+
+
+def init_db(engine: Engine) -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+def drop_db(engine: Engine) -> None:
+    Base.metadata.drop_all(bind=engine)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,129 @@
+from sqlalchemy import create_engine, inspect, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from linkedin_scrapper.models import (
+    Application,
+    ApplicationStatus,
+    Base,
+    CandidateProfile,
+    Job,
+    JobScore,
+    SearchRun,
+    SearchRunJob,
+)
+from linkedin_scrapper.services.database import init_db
+
+
+def test_init_db_creates_required_tables() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+
+    init_db(engine)
+
+    tables = set(inspect(engine).get_table_names())
+    assert {
+        "candidate_profiles",
+        "search_runs",
+        "jobs",
+        "search_run_jobs",
+        "job_scores",
+        "applications",
+    }.issubset(tables)
+
+
+def test_job_url_unique_constraint_deduplicates_jobs() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        session.add(
+            Job(
+                title="Backend Engineer",
+                company="Example",
+                url="https://www.linkedin.com/jobs/view/123",
+                raw_payload={"id": "123"},
+            )
+        )
+        session.commit()
+
+        session.add(
+            Job(
+                title="Backend Engineer",
+                company="Example",
+                url="https://www.linkedin.com/jobs/view/123",
+                raw_payload={"id": "123"},
+            )
+        )
+
+        try:
+            session.commit()
+        except IntegrityError:
+            session.rollback()
+        else:
+            raise AssertionError("Expected duplicate job URL to violate unique constraint")
+
+
+def test_application_status_can_be_updated_independently() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        job = Job(
+            title="ML Engineer",
+            company="Example",
+            url="https://www.linkedin.com/jobs/view/456",
+        )
+        application = Application(job=job)
+        session.add(application)
+        session.commit()
+
+        application.status = ApplicationStatus.APPLIED.value
+        application.notes = "Applied from dashboard"
+        session.commit()
+
+        saved = session.scalars(select(Application)).one()
+        assert saved.status == ApplicationStatus.APPLIED.value
+        assert saved.notes == "Applied from dashboard"
+
+
+def test_search_run_can_link_to_existing_deduplicated_job() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        profile = CandidateProfile(cv_text="Python backend engineer")
+        search_run = SearchRun(
+            candidate_profile=profile,
+            query="backend engineer",
+            linkedin_url="https://www.linkedin.com/jobs/search/?keywords=backend",
+            actor_name="curious_coder/linkedin-jobs-scraper",
+        )
+        job = Job(
+            title="Backend Engineer",
+            company="Example",
+            url="https://www.linkedin.com/jobs/view/789",
+        )
+        search_run.job_links.append(SearchRunJob(job=job))
+        session.add(search_run)
+        session.commit()
+
+        saved_job = session.scalars(select(Job)).one()
+        assert saved_job.search_run_links[0].search_run.query == "backend engineer"
+
+
+def test_job_score_is_one_per_job_with_score_range() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        job = Job(
+            title="Data Engineer",
+            company="Example",
+            url="https://www.linkedin.com/jobs/view/999",
+        )
+        session.add(JobScore(job=job, score=85, summary="Strong match"))
+        session.commit()
+
+        saved_score = session.scalars(select(JobScore)).one()
+        assert saved_score.score == 85
+        assert saved_score.job.title == "Data Engineer"


### PR DESCRIPTION
## Summary
- Add SQLAlchemy schema models for candidate profiles, search runs, jobs, search-run/job links, job scores, and applications.
- Add job deduplication constraints on external ID and URL, plus score/status check constraints.
- Add database init/drop helpers and a `linkedin-scrapper init-db` CLI command.
- Add SQLite-backed schema tests for table creation, job dedupe, application status updates, search-run links, and job scores.

## Validation
- `./.venv/bin/pytest`
- `./.venv/bin/python -m compileall main.py src tests`
- `./.venv/bin/ruff check .`
- `DATABASE_URL="sqlite+pysqlite:////tmp/test.db" ./.venv/bin/linkedin-scrapper init-db`

Closes #3
