### PR TITLE
[codex] Add candidate CV parser

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 APIFY_API_TOKEN=
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-4.1-mini
+OPENAI_CV_PARSER_MODEL=gpt-4.1
 DATABASE_URL=postgresql+psycopg://user:password@localhost:5432/linkedin_scrapper
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=

--- a/README.md
+++ b/README.md
@@ -38,3 +38,15 @@ Create the database schema:
 ```bash
 linkedin-scrapper init-db
 ```
+
+Parse a CV without saving:
+
+```bash
+linkedin-scrapper parse-cv ./path/to/cv.pdf
+```
+
+Parse and save a candidate profile:
+
+```bash
+linkedin-scrapper parse-cv ./path/to/cv.pdf --save
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "psycopg[binary]>=3.2.0",
     "pydantic>=2.10.0",
     "pydantic-settings>=2.8.0",
+    "pypdf>=6.0.0",
     "python-dotenv>=1.0.1",
     "resend>=2.10.0",
     "rich>=13.9.0",

--- a/src/linkedin_scrapper/cli.py
+++ b/src/linkedin_scrapper/cli.py
@@ -8,7 +8,7 @@ from linkedin_scrapper.config import Settings
 from linkedin_scrapper.cv_parser import build_cv_parser_agent, parse_cv
 from linkedin_scrapper.pipeline import PipelineRequest, build_pipeline
 from linkedin_scrapper.services.database import build_engine, drop_db, init_db
-from linkedin_scrapper.services.llm import build_chat_model
+from linkedin_scrapper.services.llm import build_cv_parser_chat_model
 from linkedin_scrapper.services.profiles import save_candidate_profile
 
 app = typer.Typer(help="LinkedIn job matching POC backend.")
@@ -61,7 +61,7 @@ def parse_candidate_cv(
         console.print({"missing_required_environment": ["DATABASE_URL"]})
         raise typer.Exit(code=1)
 
-    chat_model = build_chat_model(settings)
+    chat_model = build_cv_parser_chat_model(settings)
     parser_agent = build_cv_parser_agent(chat_model)
     parsed_profile = parse_cv(cv_path, parser_agent)
 

--- a/src/linkedin_scrapper/cli.py
+++ b/src/linkedin_scrapper/cli.py
@@ -5,9 +5,10 @@ from rich.console import Console
 from sqlalchemy.orm import Session
 
 from linkedin_scrapper.config import Settings
-from linkedin_scrapper.cv_parser import parse_cv
+from linkedin_scrapper.cv_parser import build_cv_parser_agent, parse_cv
 from linkedin_scrapper.pipeline import PipelineRequest, build_pipeline
 from linkedin_scrapper.services.database import build_engine, drop_db, init_db
+from linkedin_scrapper.services.llm import build_chat_model
 from linkedin_scrapper.services.profiles import save_candidate_profile
 
 app = typer.Typer(help="LinkedIn job matching POC backend.")
@@ -53,13 +54,19 @@ def parse_candidate_cv(
 ) -> None:
     """Parse a CV into a structured candidate profile."""
     settings = Settings()
-    parsed_profile = parse_cv(cv_path)
+    if not settings.openai_api_key:
+        console.print({"missing_required_environment": ["OPENAI_API_KEY"]})
+        raise typer.Exit(code=1)
+    if save and not settings.database_url:
+        console.print({"missing_required_environment": ["DATABASE_URL"]})
+        raise typer.Exit(code=1)
+
+    chat_model = build_chat_model(settings)
+    parser_agent = build_cv_parser_agent(chat_model)
+    parsed_profile = parse_cv(cv_path, parser_agent)
 
     output = parsed_profile.model_dump()
     if save:
-        if not settings.database_url:
-            console.print({"missing_required_environment": ["DATABASE_URL"]})
-            raise typer.Exit(code=1)
         engine = build_engine(settings)
         with Session(engine) as session:
             profile = save_candidate_profile(session, parsed_profile)

--- a/src/linkedin_scrapper/cli.py
+++ b/src/linkedin_scrapper/cli.py
@@ -2,10 +2,13 @@ from pathlib import Path
 
 import typer
 from rich.console import Console
+from sqlalchemy.orm import Session
 
 from linkedin_scrapper.config import Settings
+from linkedin_scrapper.cv_parser import parse_cv
 from linkedin_scrapper.pipeline import PipelineRequest, build_pipeline
 from linkedin_scrapper.services.database import build_engine, drop_db, init_db
+from linkedin_scrapper.services.profiles import save_candidate_profile
 
 app = typer.Typer(help="LinkedIn job matching POC backend.")
 console = Console()
@@ -37,6 +40,32 @@ def initialize_database(
         drop_db(engine)
     init_db(engine)
     console.print({"database_initialized": True, "drop_existing": drop_existing})
+
+
+@app.command("parse-cv")
+def parse_candidate_cv(
+    cv_path: Path = typer.Argument(..., help="Path to a candidate CV in .txt, .md, or .pdf format."),
+    save: bool = typer.Option(
+        False,
+        "--save",
+        help="Persist the parsed profile to the configured database.",
+    ),
+) -> None:
+    """Parse a CV into a structured candidate profile."""
+    settings = Settings()
+    parsed_profile = parse_cv(cv_path)
+
+    output = parsed_profile.model_dump()
+    if save:
+        if not settings.database_url:
+            console.print({"missing_required_environment": ["DATABASE_URL"]})
+            raise typer.Exit(code=1)
+        engine = build_engine(settings)
+        with Session(engine) as session:
+            profile = save_candidate_profile(session, parsed_profile)
+            output["id"] = str(profile.id)
+
+    console.print(output)
 
 
 @app.command("run-pipeline")

--- a/src/linkedin_scrapper/config.py
+++ b/src/linkedin_scrapper/config.py
@@ -12,6 +12,10 @@ class Settings(BaseSettings):
     apify_api_token: SecretStr | None = Field(default=None, alias="APIFY_API_TOKEN")
     openai_api_key: SecretStr | None = Field(default=None, alias="OPENAI_API_KEY")
     openai_model: str = Field(default="gpt-4.1-mini", alias="OPENAI_MODEL")
+    openai_cv_parser_model: str = Field(
+        default="gpt-4.1",
+        alias="OPENAI_CV_PARSER_MODEL",
+    )
     database_url: str | None = Field(default=None, alias="DATABASE_URL")
     resend_api_key: SecretStr | None = Field(default=None, alias="RESEND_API_KEY")
     resend_from_email: str | None = Field(default=None, alias="RESEND_FROM_EMAIL")
@@ -44,6 +48,7 @@ class Settings(BaseSettings):
             "resend_from_email": self.resend_from_email,
             "digest_to_email": self.digest_to_email,
             "openai_model": self.openai_model,
+            "openai_cv_parser_model": self.openai_cv_parser_model,
             "linkedin_jobs_actor_id": self.linkedin_jobs_actor_id,
             "default_job_count": self.default_job_count,
             "score_threshold": self.score_threshold,

--- a/src/linkedin_scrapper/cv_parser.py
+++ b/src/linkedin_scrapper/cv_parser.py
@@ -14,11 +14,12 @@ class CandidateProfileExtraction(BaseModel):
     remote_preference: str | None = None
     seniority: str | None = None
     exclusions: list[str] = Field(default_factory=list)
-    profile_payload: dict[str, Any] = Field(default_factory=dict)
+    extraction_notes: list[str] = Field(default_factory=list)
 
 
 class ParsedCandidateProfile(CandidateProfileExtraction):
     cv_text: str
+    profile_payload: dict[str, Any] = Field(default_factory=dict)
 
 
 class CVParserAgent(Protocol):
@@ -39,7 +40,7 @@ Field guidance:
 - remote_preference: one of remote, hybrid, onsite, or null.
 - seniority: junior, mid, senior, staff, principal, lead, or null.
 - exclusions: explicit constraints, avoidances, or non-target roles.
-- profile_payload: concise metadata useful for debugging extraction decisions.
+- extraction_notes: concise evidence notes useful for debugging extraction decisions.
 """.strip()
 
 
@@ -82,9 +83,9 @@ def parse_cv_text(cv_text: str, agent: CVParserAgent) -> ParsedCandidateProfile:
     )
 
     payload = {
-        **extraction.profile_payload,
         "parser": "llm-agent-v1",
         "text_length": len(normalized),
+        "extraction_notes": extraction.extraction_notes,
     }
 
     return ParsedCandidateProfile(

--- a/src/linkedin_scrapper/cv_parser.py
+++ b/src/linkedin_scrapper/cv_parser.py
@@ -1,74 +1,55 @@
 from __future__ import annotations
 
-import re
 from pathlib import Path
+from typing import Any, Protocol
 
 from pydantic import BaseModel, Field
 from pypdf import PdfReader
 
 
-class ParsedCandidateProfile(BaseModel):
-    cv_text: str
+class CandidateProfileExtraction(BaseModel):
     target_roles: list[str] = Field(default_factory=list)
     skills: list[str] = Field(default_factory=list)
     locations: list[str] = Field(default_factory=list)
     remote_preference: str | None = None
     seniority: str | None = None
     exclusions: list[str] = Field(default_factory=list)
-    profile_payload: dict = Field(default_factory=dict)
+    profile_payload: dict[str, Any] = Field(default_factory=dict)
 
 
-ROLE_PATTERNS = {
-    "AI Engineer": ("ai engineer", "artificial intelligence engineer"),
-    "Machine Learning Engineer": ("machine learning engineer", "ml engineer"),
-    "Data Engineer": ("data engineer", "data engineering"),
-    "Backend Engineer": ("backend engineer", "back-end engineer", "backend developer"),
-    "Python Developer": ("python developer", "python engineer"),
-    "Full Stack Developer": ("full stack", "full-stack"),
-    "Software Engineer": ("software engineer", "software developer"),
-}
-
-SKILL_KEYWORDS = [
-    "Python",
-    "TypeScript",
-    "JavaScript",
-    "SQL",
-    "PostgreSQL",
-    "FastAPI",
-    "Django",
-    "React",
-    "Astro",
-    "Docker",
-    "Kubernetes",
-    "AWS",
-    "GCP",
-    "Azure",
-    "LangChain",
-    "LangGraph",
-    "OpenAI",
-    "Machine Learning",
-    "Deep Learning",
-    "NLP",
-    "ETL",
-    "Airflow",
-    "dbt",
-]
-
-LOCATION_PATTERNS = [
-    "Paris",
-    "France",
-    "Lyon",
-    "Bordeaux",
-    "Remote",
-    "Europe",
-    "London",
-    "Berlin",
-]
+class ParsedCandidateProfile(CandidateProfileExtraction):
+    cv_text: str
 
 
-def parse_cv(path: Path) -> ParsedCandidateProfile:
+class CVParserAgent(Protocol):
+    def invoke(self, input: Any) -> CandidateProfileExtraction | dict[str, Any]:
+        pass
+
+
+CV_PARSER_SYSTEM_PROMPT = """
+You extract a structured candidate profile from a CV for job-search automation.
+
+Return only fields that are supported by evidence in the CV. Use empty lists or null
+when the CV does not provide enough information.
+
+Field guidance:
+- target_roles: normalized job titles the candidate is suited for.
+- skills: concrete tools, languages, frameworks, platforms, and methods.
+- locations: candidate locations or target locations.
+- remote_preference: one of remote, hybrid, onsite, or null.
+- seniority: junior, mid, senior, staff, principal, lead, or null.
+- exclusions: explicit constraints, avoidances, or non-target roles.
+- profile_payload: concise metadata useful for debugging extraction decisions.
+""".strip()
+
+
+def build_cv_parser_agent(chat_model: Any) -> CVParserAgent:
+    return chat_model.with_structured_output(CandidateProfileExtraction)
+
+
+def parse_cv(path: Path, agent: CVParserAgent) -> ParsedCandidateProfile:
     cv_text = extract_cv_text(path)
-    return parse_cv_text(cv_text)
+    return parse_cv_text(cv_text, agent)
 
 
 def extract_cv_text(path: Path) -> str:
@@ -89,29 +70,32 @@ def extract_cv_text(path: Path) -> str:
     return normalized
 
 
-def parse_cv_text(cv_text: str) -> ParsedCandidateProfile:
+def parse_cv_text(cv_text: str, agent: CVParserAgent) -> ParsedCandidateProfile:
     normalized = _normalize_text(cv_text)
-    lower = normalized.lower()
+    extraction = _coerce_extraction(
+        agent.invoke(
+            [
+                ("system", CV_PARSER_SYSTEM_PROMPT),
+                ("human", f"CV text:\n\n{normalized}"),
+            ]
+        )
+    )
 
-    target_roles = _extract_target_roles(lower)
-    skills = _extract_known_values(normalized, SKILL_KEYWORDS)
-    locations = _extract_known_values(normalized, LOCATION_PATTERNS)
-    remote_preference = _extract_remote_preference(lower)
-    seniority = _extract_seniority(lower)
-    exclusions = _extract_exclusions(normalized)
+    payload = {
+        **extraction.profile_payload,
+        "parser": "llm-agent-v1",
+        "text_length": len(normalized),
+    }
 
     return ParsedCandidateProfile(
         cv_text=normalized,
-        target_roles=target_roles,
-        skills=skills,
-        locations=locations,
-        remote_preference=remote_preference,
-        seniority=seniority,
-        exclusions=exclusions,
-        profile_payload={
-            "parser": "deterministic-v1",
-            "text_length": len(normalized),
-        },
+        target_roles=extraction.target_roles,
+        skills=extraction.skills,
+        locations=extraction.locations,
+        remote_preference=extraction.remote_preference,
+        seniority=extraction.seniority,
+        exclusions=extraction.exclusions,
+        profile_payload=payload,
     )
 
 
@@ -121,54 +105,23 @@ def _extract_pdf_text(path: Path) -> str:
 
 
 def _normalize_text(text: str) -> str:
-    return re.sub(r"\n{3,}", "\n\n", text.replace("\r\n", "\n")).strip()
+    lines = [line.rstrip() for line in text.replace("\r\n", "\n").split("\n")]
+    normalized_lines: list[str] = []
+    previous_blank = False
+
+    for line in lines:
+        is_blank = not line.strip()
+        if is_blank and previous_blank:
+            continue
+        normalized_lines.append("" if is_blank else line)
+        previous_blank = is_blank
+
+    return "\n".join(normalized_lines).strip()
 
 
-def _extract_target_roles(lower_text: str) -> list[str]:
-    roles = [
-        role
-        for role, patterns in ROLE_PATTERNS.items()
-        if any(pattern in lower_text for pattern in patterns)
-    ]
-    return roles or ["Software Engineer"]
-
-
-def _extract_known_values(text: str, values: list[str]) -> list[str]:
-    found = []
-    for value in values:
-        if re.search(rf"(?<!\w){re.escape(value)}(?!\w)", text, flags=re.IGNORECASE):
-            found.append(value)
-    return found
-
-
-def _extract_remote_preference(lower_text: str) -> str | None:
-    if "remote" in lower_text or "télétravail" in lower_text or "teletravail" in lower_text:
-        return "remote"
-    if "hybrid" in lower_text or "hybride" in lower_text:
-        return "hybrid"
-    if "on-site" in lower_text or "onsite" in lower_text or "présentiel" in lower_text:
-        return "onsite"
-    return None
-
-
-def _extract_seniority(lower_text: str) -> str | None:
-    if "principal" in lower_text or "staff" in lower_text:
-        return "staff"
-    if "senior" in lower_text or "lead" in lower_text:
-        return "senior"
-    if "junior" in lower_text or "entry level" in lower_text:
-        return "junior"
-    if re.search(r"\b[4-9]\+?\s+(years|ans)\b", lower_text):
-        return "senior"
-    if re.search(r"\b[1-3]\+?\s+(years|ans)\b", lower_text):
-        return "mid"
-    return None
-
-
-def _extract_exclusions(text: str) -> list[str]:
-    exclusions = []
-    for line in text.splitlines():
-        lower = line.lower()
-        if any(marker in lower for marker in ("not interested", "exclude", "avoid", "pas intéressé")):
-            exclusions.append(line.strip())
-    return exclusions
+def _coerce_extraction(
+    extraction: CandidateProfileExtraction | dict[str, Any],
+) -> CandidateProfileExtraction:
+    if isinstance(extraction, CandidateProfileExtraction):
+        return extraction
+    return CandidateProfileExtraction.model_validate(extraction)

--- a/src/linkedin_scrapper/cv_parser.py
+++ b/src/linkedin_scrapper/cv_parser.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+from pypdf import PdfReader
+
+
+class ParsedCandidateProfile(BaseModel):
+    cv_text: str
+    target_roles: list[str] = Field(default_factory=list)
+    skills: list[str] = Field(default_factory=list)
+    locations: list[str] = Field(default_factory=list)
+    remote_preference: str | None = None
+    seniority: str | None = None
+    exclusions: list[str] = Field(default_factory=list)
+    profile_payload: dict = Field(default_factory=dict)
+
+
+ROLE_PATTERNS = {
+    "AI Engineer": ("ai engineer", "artificial intelligence engineer"),
+    "Machine Learning Engineer": ("machine learning engineer", "ml engineer"),
+    "Data Engineer": ("data engineer", "data engineering"),
+    "Backend Engineer": ("backend engineer", "back-end engineer", "backend developer"),
+    "Python Developer": ("python developer", "python engineer"),
+    "Full Stack Developer": ("full stack", "full-stack"),
+    "Software Engineer": ("software engineer", "software developer"),
+}
+
+SKILL_KEYWORDS = [
+    "Python",
+    "TypeScript",
+    "JavaScript",
+    "SQL",
+    "PostgreSQL",
+    "FastAPI",
+    "Django",
+    "React",
+    "Astro",
+    "Docker",
+    "Kubernetes",
+    "AWS",
+    "GCP",
+    "Azure",
+    "LangChain",
+    "LangGraph",
+    "OpenAI",
+    "Machine Learning",
+    "Deep Learning",
+    "NLP",
+    "ETL",
+    "Airflow",
+    "dbt",
+]
+
+LOCATION_PATTERNS = [
+    "Paris",
+    "France",
+    "Lyon",
+    "Bordeaux",
+    "Remote",
+    "Europe",
+    "London",
+    "Berlin",
+]
+
+
+def parse_cv(path: Path) -> ParsedCandidateProfile:
+    cv_text = extract_cv_text(path)
+    return parse_cv_text(cv_text)
+
+
+def extract_cv_text(path: Path) -> str:
+    if not path.exists():
+        raise FileNotFoundError(f"CV file not found: {path}")
+
+    suffix = path.suffix.lower()
+    if suffix in {".txt", ".md"}:
+        text = path.read_text(encoding="utf-8")
+    elif suffix == ".pdf":
+        text = _extract_pdf_text(path)
+    else:
+        raise ValueError("Unsupported CV format. Use .txt, .md, or .pdf.")
+
+    normalized = _normalize_text(text)
+    if not normalized:
+        raise ValueError(f"CV file does not contain extractable text: {path}")
+    return normalized
+
+
+def parse_cv_text(cv_text: str) -> ParsedCandidateProfile:
+    normalized = _normalize_text(cv_text)
+    lower = normalized.lower()
+
+    target_roles = _extract_target_roles(lower)
+    skills = _extract_known_values(normalized, SKILL_KEYWORDS)
+    locations = _extract_known_values(normalized, LOCATION_PATTERNS)
+    remote_preference = _extract_remote_preference(lower)
+    seniority = _extract_seniority(lower)
+    exclusions = _extract_exclusions(normalized)
+
+    return ParsedCandidateProfile(
+        cv_text=normalized,
+        target_roles=target_roles,
+        skills=skills,
+        locations=locations,
+        remote_preference=remote_preference,
+        seniority=seniority,
+        exclusions=exclusions,
+        profile_payload={
+            "parser": "deterministic-v1",
+            "text_length": len(normalized),
+        },
+    )
+
+
+def _extract_pdf_text(path: Path) -> str:
+    reader = PdfReader(str(path))
+    return "\n".join(page.extract_text() or "" for page in reader.pages)
+
+
+def _normalize_text(text: str) -> str:
+    return re.sub(r"\n{3,}", "\n\n", text.replace("\r\n", "\n")).strip()
+
+
+def _extract_target_roles(lower_text: str) -> list[str]:
+    roles = [
+        role
+        for role, patterns in ROLE_PATTERNS.items()
+        if any(pattern in lower_text for pattern in patterns)
+    ]
+    return roles or ["Software Engineer"]
+
+
+def _extract_known_values(text: str, values: list[str]) -> list[str]:
+    found = []
+    for value in values:
+        if re.search(rf"(?<!\w){re.escape(value)}(?!\w)", text, flags=re.IGNORECASE):
+            found.append(value)
+    return found
+
+
+def _extract_remote_preference(lower_text: str) -> str | None:
+    if "remote" in lower_text or "télétravail" in lower_text or "teletravail" in lower_text:
+        return "remote"
+    if "hybrid" in lower_text or "hybride" in lower_text:
+        return "hybrid"
+    if "on-site" in lower_text or "onsite" in lower_text or "présentiel" in lower_text:
+        return "onsite"
+    return None
+
+
+def _extract_seniority(lower_text: str) -> str | None:
+    if "principal" in lower_text or "staff" in lower_text:
+        return "staff"
+    if "senior" in lower_text or "lead" in lower_text:
+        return "senior"
+    if "junior" in lower_text or "entry level" in lower_text:
+        return "junior"
+    if re.search(r"\b[4-9]\+?\s+(years|ans)\b", lower_text):
+        return "senior"
+    if re.search(r"\b[1-3]\+?\s+(years|ans)\b", lower_text):
+        return "mid"
+    return None
+
+
+def _extract_exclusions(text: str) -> list[str]:
+    exclusions = []
+    for line in text.splitlines():
+        lower = line.lower()
+        if any(marker in lower for marker in ("not interested", "exclude", "avoid", "pas intéressé")):
+            exclusions.append(line.strip())
+    return exclusions

--- a/src/linkedin_scrapper/pipeline.py
+++ b/src/linkedin_scrapper/pipeline.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from linkedin_scrapper.config import Settings
+from linkedin_scrapper.cv_parser import ParsedCandidateProfile, parse_cv
 
 
 @dataclass(frozen=True)
@@ -13,6 +14,7 @@ class PipelineRequest:
 class PipelineResult:
     status: str
     steps: list[str]
+    candidate_profile: ParsedCandidateProfile | None = None
 
 
 class JobMatchingPipeline:
@@ -32,9 +34,11 @@ class JobMatchingPipeline:
         if not request.cv_path.exists():
             raise FileNotFoundError(f"CV file not found: {request.cv_path}")
 
+        candidate_profile = parse_cv(request.cv_path)
         return PipelineResult(
             status="not_implemented",
             steps=self.steps,
+            candidate_profile=candidate_profile,
         )
 
 

--- a/src/linkedin_scrapper/pipeline.py
+++ b/src/linkedin_scrapper/pipeline.py
@@ -7,7 +7,7 @@ from linkedin_scrapper.cv_parser import (
     build_cv_parser_agent,
     parse_cv,
 )
-from linkedin_scrapper.services.llm import build_chat_model
+from linkedin_scrapper.services.llm import build_cv_parser_chat_model
 
 
 @dataclass(frozen=True)
@@ -39,7 +39,7 @@ class JobMatchingPipeline:
         if not request.cv_path.exists():
             raise FileNotFoundError(f"CV file not found: {request.cv_path}")
 
-        chat_model = build_chat_model(self.settings)
+        chat_model = build_cv_parser_chat_model(self.settings)
         parser_agent = build_cv_parser_agent(chat_model)
         candidate_profile = parse_cv(request.cv_path, parser_agent)
         return PipelineResult(

--- a/src/linkedin_scrapper/pipeline.py
+++ b/src/linkedin_scrapper/pipeline.py
@@ -2,7 +2,12 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from linkedin_scrapper.config import Settings
-from linkedin_scrapper.cv_parser import ParsedCandidateProfile, parse_cv
+from linkedin_scrapper.cv_parser import (
+    ParsedCandidateProfile,
+    build_cv_parser_agent,
+    parse_cv,
+)
+from linkedin_scrapper.services.llm import build_chat_model
 
 
 @dataclass(frozen=True)
@@ -34,7 +39,9 @@ class JobMatchingPipeline:
         if not request.cv_path.exists():
             raise FileNotFoundError(f"CV file not found: {request.cv_path}")
 
-        candidate_profile = parse_cv(request.cv_path)
+        chat_model = build_chat_model(self.settings)
+        parser_agent = build_cv_parser_agent(chat_model)
+        candidate_profile = parse_cv(request.cv_path, parser_agent)
         return PipelineResult(
             status="not_implemented",
             steps=self.steps,

--- a/src/linkedin_scrapper/services/llm.py
+++ b/src/linkedin_scrapper/services/llm.py
@@ -11,3 +11,13 @@ def build_chat_model(settings: Settings) -> ChatOpenAI:
         model=settings.openai_model,
         api_key=settings.openai_api_key.get_secret_value(),
     )
+
+
+def build_cv_parser_chat_model(settings: Settings) -> ChatOpenAI:
+    if settings.openai_api_key is None:
+        raise RuntimeError("OPENAI_API_KEY is required to build the CV parser chat model.")
+
+    return ChatOpenAI(
+        model=settings.openai_cv_parser_model,
+        api_key=settings.openai_api_key.get_secret_value(),
+    )

--- a/src/linkedin_scrapper/services/profiles.py
+++ b/src/linkedin_scrapper/services/profiles.py
@@ -1,0 +1,24 @@
+from sqlalchemy.orm import Session
+
+from linkedin_scrapper.cv_parser import ParsedCandidateProfile
+from linkedin_scrapper.models import CandidateProfile
+
+
+def save_candidate_profile(
+    session: Session,
+    parsed_profile: ParsedCandidateProfile,
+) -> CandidateProfile:
+    profile = CandidateProfile(
+        cv_text=parsed_profile.cv_text,
+        target_roles=parsed_profile.target_roles,
+        skills=parsed_profile.skills,
+        locations=parsed_profile.locations,
+        remote_preference=parsed_profile.remote_preference,
+        seniority=parsed_profile.seniority,
+        exclusions=parsed_profile.exclusions,
+        profile_payload=parsed_profile.profile_payload,
+    )
+    session.add(profile)
+    session.commit()
+    session.refresh(profile)
+    return profile

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,3 +45,14 @@ def test_openai_model_is_configurable(monkeypatch) -> None:
 
     assert settings.openai_model == "gpt-4.1"
     assert settings.safe_dump()["openai_model"] == "gpt-4.1"
+
+
+def test_cv_parser_model_is_configurable_without_changing_default_model(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4.1-mini")
+    monkeypatch.setenv("OPENAI_CV_PARSER_MODEL", "gpt-4.1")
+
+    settings = Settings()
+
+    assert settings.openai_model == "gpt-4.1-mini"
+    assert settings.openai_cv_parser_model == "gpt-4.1"
+    assert settings.safe_dump()["openai_cv_parser_model"] == "gpt-4.1"

--- a/tests/test_cv_parser.py
+++ b/tests/test_cv_parser.py
@@ -1,0 +1,120 @@
+from pathlib import Path
+
+import pytest
+from pypdf import PdfWriter
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+from typer.testing import CliRunner
+
+from linkedin_scrapper.cli import app
+from linkedin_scrapper.cv_parser import extract_cv_text, parse_cv, parse_cv_text
+from linkedin_scrapper.models import Base, CandidateProfile
+from linkedin_scrapper.services.profiles import save_candidate_profile
+
+
+def test_parse_cv_text_extracts_structured_profile() -> None:
+    profile = parse_cv_text(
+        """
+        Senior Backend Engineer based in Paris, France.
+        6 years building Python, PostgreSQL, FastAPI, Docker and LangGraph systems.
+        Looking for remote AI Engineer or Data Engineer roles.
+        Not interested in PHP roles.
+        """
+    )
+
+    assert "Backend Engineer" in profile.target_roles
+    assert "AI Engineer" in profile.target_roles
+    assert "Data Engineer" in profile.target_roles
+    assert {"Python", "PostgreSQL", "FastAPI", "Docker", "LangGraph"}.issubset(
+        profile.skills
+    )
+    assert {"Paris", "France", "Remote"}.issubset(profile.locations)
+    assert profile.remote_preference == "remote"
+    assert profile.seniority == "senior"
+    assert profile.exclusions == ["Not interested in PHP roles."]
+    assert profile.profile_payload["parser"] == "deterministic-v1"
+
+
+def test_parse_cv_reads_text_file(tmp_path: Path) -> None:
+    cv_path = tmp_path / "cv.txt"
+    cv_path.write_text("Python Software Engineer in Berlin", encoding="utf-8")
+
+    profile = parse_cv(cv_path)
+
+    assert profile.cv_text == "Python Software Engineer in Berlin"
+    assert "Software Engineer" in profile.target_roles
+    assert "Python" in profile.skills
+    assert "Berlin" in profile.locations
+
+
+def test_extract_cv_text_accepts_pdf_and_rejects_empty_pdf(tmp_path: Path) -> None:
+    cv_path = tmp_path / "cv.pdf"
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    with cv_path.open("wb") as file:
+        writer.write(file)
+
+    with pytest.raises(ValueError, match="does not contain extractable text"):
+        extract_cv_text(cv_path)
+
+
+def test_save_candidate_profile_persists_parsed_profile() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    parsed_profile = parse_cv_text("Senior Python Backend Engineer in Paris")
+
+    with Session(engine) as session:
+        saved = save_candidate_profile(session, parsed_profile)
+
+        profile = session.scalars(select(CandidateProfile)).one()
+        assert profile.id == saved.id
+        assert profile.cv_text == parsed_profile.cv_text
+        assert profile.target_roles == parsed_profile.target_roles
+        assert profile.skills == parsed_profile.skills
+        assert profile.locations == parsed_profile.locations
+
+
+def test_parse_cv_cli_outputs_profile(tmp_path: Path) -> None:
+    cv_path = tmp_path / "cv.md"
+    cv_path.write_text("Senior Python Data Engineer - Remote Europe", encoding="utf-8")
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["parse-cv", str(cv_path)])
+
+    assert result.exit_code == 0
+    assert "Data Engineer" in result.output
+    assert "Python" in result.output
+    assert "Remote" in result.output
+
+
+def test_parse_cv_cli_save_requires_database_url(tmp_path: Path, monkeypatch) -> None:
+    cv_path = tmp_path / "cv.txt"
+    cv_path.write_text("Python Backend Engineer", encoding="utf-8")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["parse-cv", str(cv_path), "--save"])
+
+    assert result.exit_code == 1
+    assert "DATABASE_URL" in result.output
+
+
+def test_parse_cv_cli_save_persists_profile(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "profiles.db"
+    cv_path = tmp_path / "cv.txt"
+    cv_path.write_text("Senior Python Backend Engineer in Paris", encoding="utf-8")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+pysqlite:///{db_path}")
+    runner = CliRunner()
+
+    init_result = runner.invoke(app, ["init-db"])
+    parse_result = runner.invoke(app, ["parse-cv", str(cv_path), "--save"])
+
+    assert init_result.exit_code == 0
+    assert parse_result.exit_code == 0
+
+    engine = create_engine(f"sqlite+pysqlite:///{db_path}")
+    with Session(engine) as session:
+        profile = session.scalars(select(CandidateProfile)).one()
+        assert profile.cv_text == "Senior Python Backend Engineer in Paris"
+        assert "Backend Engineer" in profile.target_roles
+        assert "Python" in profile.skills

--- a/tests/test_cv_parser.py
+++ b/tests/test_cv_parser.py
@@ -27,7 +27,7 @@ class StubCVParserAgent:
             remote_preference="remote",
             seniority="senior",
             exclusions=["Not interested in PHP roles."],
-            profile_payload={"evidence": "stubbed"},
+            extraction_notes=["stubbed evidence"],
         )
         self.inputs: list[Any] = []
 
@@ -68,6 +68,7 @@ def test_parse_cv_text_uses_agent_to_extract_structured_profile() -> None:
     assert profile.seniority == "senior"
     assert profile.exclusions == ["Not interested in PHP roles."]
     assert profile.profile_payload["parser"] == "llm-agent-v1"
+    assert profile.profile_payload["extraction_notes"] == ["stubbed evidence"]
     assert agent.inputs
 
 
@@ -138,7 +139,7 @@ def test_parse_cv_cli_save_requires_database_url(tmp_path: Path, monkeypatch) ->
     cv_path = tmp_path / "cv.txt"
     cv_path.write_text("Python Backend Engineer", encoding="utf-8")
     _patch_cli_agent(monkeypatch)
-    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("DATABASE_URL", "")
     runner = CliRunner()
 
     result = runner.invoke(app, ["parse-cv", str(cv_path), "--save"])

--- a/tests/test_cv_parser.py
+++ b/tests/test_cv_parser.py
@@ -174,6 +174,6 @@ def _patch_cli_agent(monkeypatch: pytest.MonkeyPatch) -> None:
     agent = StubCVParserAgent()
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.setattr(
-        "linkedin_scrapper.cli.build_chat_model",
+        "linkedin_scrapper.cli.build_cv_parser_chat_model",
         lambda settings: StubChatModel(agent),
     )

--- a/tests/test_cv_parser.py
+++ b/tests/test_cv_parser.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 
 import pytest
 from pypdf import PdfWriter
@@ -7,19 +8,53 @@ from sqlalchemy.orm import Session
 from typer.testing import CliRunner
 
 from linkedin_scrapper.cli import app
-from linkedin_scrapper.cv_parser import extract_cv_text, parse_cv, parse_cv_text
+from linkedin_scrapper.cv_parser import (
+    CandidateProfileExtraction,
+    extract_cv_text,
+    parse_cv,
+    parse_cv_text,
+)
 from linkedin_scrapper.models import Base, CandidateProfile
 from linkedin_scrapper.services.profiles import save_candidate_profile
 
 
-def test_parse_cv_text_extracts_structured_profile() -> None:
+class StubCVParserAgent:
+    def __init__(self, extraction: CandidateProfileExtraction | None = None) -> None:
+        self.extraction = extraction or CandidateProfileExtraction(
+            target_roles=["Backend Engineer", "AI Engineer", "Data Engineer"],
+            skills=["Python", "PostgreSQL", "FastAPI", "Docker", "LangGraph"],
+            locations=["Paris", "France", "Remote"],
+            remote_preference="remote",
+            seniority="senior",
+            exclusions=["Not interested in PHP roles."],
+            profile_payload={"evidence": "stubbed"},
+        )
+        self.inputs: list[Any] = []
+
+    def invoke(self, input: Any) -> CandidateProfileExtraction:
+        self.inputs.append(input)
+        return self.extraction
+
+
+class StubChatModel:
+    def __init__(self, agent: StubCVParserAgent) -> None:
+        self.agent = agent
+
+    def with_structured_output(self, schema: type[CandidateProfileExtraction]) -> StubCVParserAgent:
+        return self.agent
+
+
+def test_parse_cv_text_uses_agent_to_extract_structured_profile() -> None:
+    agent = StubCVParserAgent()
+
     profile = parse_cv_text(
         """
         Senior Backend Engineer based in Paris, France.
         6 years building Python, PostgreSQL, FastAPI, Docker and LangGraph systems.
         Looking for remote AI Engineer or Data Engineer roles.
         Not interested in PHP roles.
-        """
+        """,
+        agent,
     )
 
     assert "Backend Engineer" in profile.target_roles
@@ -32,14 +67,22 @@ def test_parse_cv_text_extracts_structured_profile() -> None:
     assert profile.remote_preference == "remote"
     assert profile.seniority == "senior"
     assert profile.exclusions == ["Not interested in PHP roles."]
-    assert profile.profile_payload["parser"] == "deterministic-v1"
+    assert profile.profile_payload["parser"] == "llm-agent-v1"
+    assert agent.inputs
 
 
 def test_parse_cv_reads_text_file(tmp_path: Path) -> None:
     cv_path = tmp_path / "cv.txt"
     cv_path.write_text("Python Software Engineer in Berlin", encoding="utf-8")
+    agent = StubCVParserAgent(
+        CandidateProfileExtraction(
+            target_roles=["Software Engineer"],
+            skills=["Python"],
+            locations=["Berlin"],
+        )
+    )
 
-    profile = parse_cv(cv_path)
+    profile = parse_cv(cv_path, agent)
 
     assert profile.cv_text == "Python Software Engineer in Berlin"
     assert "Software Engineer" in profile.target_roles
@@ -61,7 +104,10 @@ def test_extract_cv_text_accepts_pdf_and_rejects_empty_pdf(tmp_path: Path) -> No
 def test_save_candidate_profile_persists_parsed_profile() -> None:
     engine = create_engine("sqlite+pysqlite:///:memory:")
     Base.metadata.create_all(engine)
-    parsed_profile = parse_cv_text("Senior Python Backend Engineer in Paris")
+    parsed_profile = parse_cv_text(
+        "Senior Python Backend Engineer in Paris",
+        StubCVParserAgent(),
+    )
 
     with Session(engine) as session:
         saved = save_candidate_profile(session, parsed_profile)
@@ -74,9 +120,10 @@ def test_save_candidate_profile_persists_parsed_profile() -> None:
         assert profile.locations == parsed_profile.locations
 
 
-def test_parse_cv_cli_outputs_profile(tmp_path: Path) -> None:
+def test_parse_cv_cli_outputs_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     cv_path = tmp_path / "cv.md"
     cv_path.write_text("Senior Python Data Engineer - Remote Europe", encoding="utf-8")
+    _patch_cli_agent(monkeypatch)
     runner = CliRunner()
 
     result = runner.invoke(app, ["parse-cv", str(cv_path)])
@@ -90,6 +137,7 @@ def test_parse_cv_cli_outputs_profile(tmp_path: Path) -> None:
 def test_parse_cv_cli_save_requires_database_url(tmp_path: Path, monkeypatch) -> None:
     cv_path = tmp_path / "cv.txt"
     cv_path.write_text("Python Backend Engineer", encoding="utf-8")
+    _patch_cli_agent(monkeypatch)
     monkeypatch.delenv("DATABASE_URL", raising=False)
     runner = CliRunner()
 
@@ -104,6 +152,7 @@ def test_parse_cv_cli_save_persists_profile(tmp_path: Path, monkeypatch) -> None
     cv_path = tmp_path / "cv.txt"
     cv_path.write_text("Senior Python Backend Engineer in Paris", encoding="utf-8")
     monkeypatch.setenv("DATABASE_URL", f"sqlite+pysqlite:///{db_path}")
+    _patch_cli_agent(monkeypatch)
     runner = CliRunner()
 
     init_result = runner.invoke(app, ["init-db"])
@@ -118,3 +167,12 @@ def test_parse_cv_cli_save_persists_profile(tmp_path: Path, monkeypatch) -> None
         assert profile.cv_text == "Senior Python Backend Engineer in Paris"
         assert "Backend Engineer" in profile.target_roles
         assert "Python" in profile.skills
+
+
+def _patch_cli_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    agent = StubCVParserAgent()
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(
+        "linkedin_scrapper.cli.build_chat_model",
+        lambda settings: StubChatModel(agent),
+    )


### PR DESCRIPTION
## Summary
- Add deterministic POC CV parsing for `.txt`, `.md`, and `.pdf` files.
- Produce a validated structured candidate profile with target roles, skills, locations, remote preference, seniority, exclusions, and parser metadata.
- Add `linkedin-scrapper parse-cv` with optional `--save` persistence to `candidate_profiles`.
- Wire CV parsing into the pipeline skeleton so the profile is reusable by later search-generation work.

## Validation
- `./.venv/bin/pytest`
- `./.venv/bin/python -m compileall main.py src tests`
- `./.venv/bin/ruff check .`
- `linkedin-scrapper parse-cv` tested manually against a temporary text CV

Closes #4
