### PR TITLE
[codex] Normalize and deduplicate Apify jobs

### DIFF
--- a/src/linkedin_scrapper/cv_parser.py
+++ b/src/linkedin_scrapper/cv_parser.py
@@ -38,12 +38,17 @@ Field guidance:
 - target_roles: normalized job titles the candidate is suited for.
 - skills: concrete tools, languages, frameworks, platforms, and methods.
 - locations: only current residence/base location and explicit target job-search
-  locations.
+  locations. Do not include historical work, education, client, employer, travel,
+  or project locations unless the CV explicitly states the candidate wants jobs
+  there. For LinkedIn exports, prefer the profile header/contact location over
+  experience locations.
 - remote_preference: one of remote, hybrid, onsite, or null.
 - seniority: junior, mid, senior, staff, principal, lead, or null. 
 - exclusions: explicit constraints, avoidances, or non-target roles.
 - extraction_notes: concise evidence notes useful for debugging extraction decisions.
 
+When location evidence conflicts, explain the decision in extraction_notes and keep
+locations focused on job-search geography, not the candidate's full work history.
 """.strip()
 
 

--- a/src/linkedin_scrapper/search_planner.py
+++ b/src/linkedin_scrapper/search_planner.py
@@ -48,11 +48,17 @@ exhaustive list of the candidate's skills.
 Rules:
 - Return up to the requested maximum number of searches.
 - Prefer fewer, stronger searches over many narrow variants.
+- Each search must target a distinct hiring angle, for example AI/LLM, Python
+  backend, full-stack, Django/React, or automation. Do not return near-duplicates
+  such as "AI Engineer" and "AI Developer" unless the keywords cover clearly
+  different job markets.
 - Keywords must be concise LinkedIn queries: use a job title plus 1 to 3 core
   skills, usually 3 to 6 words total. Avoid long keyword lists.
 - Do not stuff every matching skill into keywords. Put supporting technologies in
   the rationale instead.
 - Avoid niche tools as primary keywords unless they are central to a target role.
+  Examples of niche terms to avoid in broad searches: Pinecone, Wagtail,
+  Speech-to-Text, specific vector database vendors.
 - Do not mix unrelated stacks in one query unless the target role genuinely
   requires them. Prefer "Django React Developer" over a long Django/Laravel/Wagtail
   combined query.

--- a/src/linkedin_scrapper/services/apify.py
+++ b/src/linkedin_scrapper/services/apify.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
 from apify_client import ApifyClient
-from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from linkedin_scrapper.config import Settings
-from linkedin_scrapper.models import Job, SearchRun, SearchRunJob, SearchRunStatus
+from linkedin_scrapper.models import SearchRun, SearchRunStatus
+from linkedin_scrapper.services.jobs import persist_apify_jobs
 
 
 def build_apify_client(settings: Settings) -> ApifyClient:
@@ -64,7 +63,7 @@ def scrape_linkedin_jobs_for_search_run(
             clean=True,
         )
         raw_items = list(getattr(dataset_items, "items", []))
-        jobs_saved = _persist_apify_jobs(session, search_run, raw_items)
+        jobs_saved = persist_apify_jobs(session, search_run, raw_items)
 
         search_run.status = SearchRunStatus.SUCCEEDED.value
         search_run.completed_at = datetime.now(UTC)
@@ -90,137 +89,3 @@ def scrape_linkedin_jobs_for_search_run(
             jobs_saved=0,
             error_message=search_run.error_message,
         )
-
-
-def _persist_apify_jobs(
-    session: Session,
-    search_run: SearchRun,
-    raw_items: list[dict[str, Any]],
-) -> int:
-    jobs_saved = 0
-    for item in raw_items:
-        job = _upsert_job_from_apify_item(session, item)
-        if job is None:
-            continue
-        session.flush()
-        link = session.get(SearchRunJob, (search_run.id, job.id))
-        if link is None:
-            session.add(SearchRunJob(search_run=search_run, job=job))
-        jobs_saved += 1
-    session.flush()
-    return jobs_saved
-
-
-def _upsert_job_from_apify_item(session: Session, item: dict[str, Any]) -> Job | None:
-    url = _extract_job_url(item)
-    external_id = _extract_external_id(item, url)
-    if not url:
-        return None
-
-    job_by_url = session.scalars(select(Job).where(Job.url == url)).first()
-    job_by_external_id = (
-        session.scalars(select(Job).where(Job.external_id == external_id)).first()
-        if external_id
-        else None
-    )
-    job = job_by_url or job_by_external_id
-
-    if job is None:
-        job = Job(title=_extract_title(item), url=url)
-        session.add(job)
-
-    if job.external_id is None and external_id and (
-        job_by_external_id is None or job_by_external_id.id == job.id
-    ):
-        job.external_id = external_id
-
-    job.title = _extract_title(item)
-    job.company = _extract_company(item)
-    job.location = _first_text(item, "location", "jobLocation", "formattedLocation")
-    job.apply_url = _first_text(item, "applyUrl", "apply_url", "externalApplyUrl")
-    job.description = _first_text(item, "description", "jobDescription", "text")
-    job.salary = _first_text(item, "salary", "salaryInfo", "compensation")
-    job.remote = _extract_remote(item)
-    job.posted_at = _extract_posted_at(item)
-    job.raw_payload = item
-    return job
-
-
-def _extract_job_url(item: dict[str, Any]) -> str | None:
-    url = _first_text(
-        item,
-        "url",
-        "jobUrl",
-        "job_url",
-        "link",
-        "jobLink",
-        "linkedinUrl",
-    )
-    if url:
-        return url
-
-    external_id = _first_text(item, "id", "jobId", "job_id", "linkedinJobId")
-    if external_id:
-        return f"https://www.linkedin.com/jobs/view/{external_id}"
-    return None
-
-
-def _extract_external_id(item: dict[str, Any], url: str | None) -> str | None:
-    external_id = _first_text(item, "id", "jobId", "job_id", "linkedinJobId")
-    if external_id:
-        return external_id
-    if not url:
-        return None
-    match = re.search(r"/jobs/view/(\d+)", url)
-    return match.group(1) if match else None
-
-
-def _extract_title(item: dict[str, Any]) -> str:
-    return _first_text(item, "title", "jobTitle", "positionName") or "Untitled LinkedIn job"
-
-
-def _extract_company(item: dict[str, Any]) -> str | None:
-    company = item.get("company")
-    if isinstance(company, dict):
-        nested = _first_text(company, "name", "companyName")
-        if nested:
-            return nested
-    return _first_text(item, "companyName", "company", "company_name")
-
-
-def _extract_remote(item: dict[str, Any]) -> bool | None:
-    for key in ("remote", "isRemote", "remoteAllowed"):
-        value = item.get(key)
-        if isinstance(value, bool):
-            return value
-
-    workplace = _first_text(item, "workplaceType", "workType", "workplace")
-    if workplace:
-        normalized = workplace.lower()
-        if "remote" in normalized or "à distance" in normalized:
-            return True
-        if "on-site" in normalized or "onsite" in normalized or "hybrid" in normalized:
-            return False
-    return None
-
-
-def _extract_posted_at(item: dict[str, Any]) -> datetime | None:
-    value = _first_text(item, "postedAt", "posted_at", "listedAt", "createdAt")
-    if not value:
-        return None
-    try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-
-
-def _first_text(item: dict[str, Any], *keys: str) -> str | None:
-    for key in keys:
-        value = item.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-        if isinstance(value, int | float):
-            return str(value)
-        if isinstance(value, dict | list) and value:
-            return str(value)
-    return None

--- a/src/linkedin_scrapper/services/jobs.py
+++ b/src/linkedin_scrapper/services/jobs.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from linkedin_scrapper.models import Job, SearchRun, SearchRunJob
+
+
+def persist_apify_jobs(
+    session: Session,
+    search_run: SearchRun,
+    raw_items: list[dict[str, Any]],
+) -> int:
+    jobs_saved = 0
+    for item in raw_items:
+        normalized = normalize_apify_job(item)
+        if normalized is None:
+            continue
+
+        job = upsert_job(session, normalized)
+        session.flush()
+
+        link = session.get(SearchRunJob, (search_run.id, job.id))
+        if link is None:
+            session.add(SearchRunJob(search_run=search_run, job=job))
+        jobs_saved += 1
+
+    session.flush()
+    return jobs_saved
+
+
+def normalize_apify_job(item: dict[str, Any]) -> dict[str, Any] | None:
+    url = _extract_job_url(item)
+    external_id = _extract_external_id(item, url)
+    apply_url = _first_text(item, "applyUrl", "apply_url", "externalApplyUrl")
+
+    if not any([external_id, url, apply_url]):
+        return None
+    if not url and external_id:
+        url = f"https://www.linkedin.com/jobs/view/{external_id}"
+
+    return {
+        "external_id": external_id,
+        "title": _extract_title(item),
+        "company": _extract_company(item),
+        "location": _first_text(item, "location", "jobLocation", "formattedLocation"),
+        "url": url,
+        "apply_url": apply_url,
+        "description": _first_text(
+            item,
+            "descriptionText",
+            "description",
+            "jobDescription",
+            "text",
+            "descriptionHtml",
+        ),
+        "salary": _extract_salary(item),
+        "remote": _extract_remote(item),
+        "posted_at": _extract_posted_at(item),
+        "raw_payload": item,
+    }
+
+
+def upsert_job(session: Session, normalized: dict[str, Any]) -> Job:
+    job = _find_existing_job(session, normalized)
+    if job is None:
+        job = Job(
+            title=normalized["title"],
+            url=normalized["url"] or normalized["apply_url"],
+        )
+        session.add(job)
+
+    if job.external_id is None:
+        job.external_id = normalized["external_id"]
+    _update_url_if_safe(session, job, normalized["url"])
+
+    job.title = normalized["title"]
+    job.company = normalized["company"]
+    job.location = normalized["location"]
+    job.apply_url = normalized["apply_url"]
+    job.description = normalized["description"]
+    job.salary = normalized["salary"]
+    job.remote = normalized["remote"]
+    job.posted_at = normalized["posted_at"]
+    job.raw_payload = normalized["raw_payload"]
+    return job
+
+
+def _update_url_if_safe(session: Session, job: Job, url: str | None) -> None:
+    if not url or job.url == url:
+        return
+
+    existing = session.scalars(select(Job).where(Job.url == url)).first()
+    if existing is None or existing.id == job.id:
+        job.url = url
+
+
+def _find_existing_job(session: Session, normalized: dict[str, Any]) -> Job | None:
+    external_id = normalized["external_id"]
+    if external_id:
+        job = session.scalars(select(Job).where(Job.external_id == external_id)).first()
+        if job is not None:
+            return job
+
+    url = normalized["url"]
+    if url:
+        job = session.scalars(select(Job).where(Job.url == url)).first()
+        if job is not None:
+            return job
+
+    apply_url = normalized["apply_url"]
+    if apply_url:
+        return session.scalars(select(Job).where(Job.apply_url == apply_url)).first()
+
+    return None
+
+
+def _extract_job_url(item: dict[str, Any]) -> str | None:
+    return _first_text(
+        item,
+        "link",
+        "url",
+        "jobUrl",
+        "job_url",
+        "jobLink",
+        "linkedinUrl",
+    )
+
+
+def _extract_external_id(item: dict[str, Any], url: str | None) -> str | None:
+    external_id = _first_text(item, "id", "jobId", "job_id", "linkedinJobId")
+    if external_id:
+        return external_id
+    if not url:
+        return None
+    match = re.search(r"/jobs/view/([^/?]+)", url)
+    return match.group(1) if match else None
+
+
+def _extract_title(item: dict[str, Any]) -> str:
+    return _first_text(item, "title", "standardizedTitle", "jobTitle", "positionName") or (
+        "Untitled LinkedIn job"
+    )
+
+
+def _extract_company(item: dict[str, Any]) -> str | None:
+    company = item.get("company")
+    if isinstance(company, dict):
+        nested = _first_text(company, "name", "companyName")
+        if nested:
+            return nested
+    return _first_text(item, "companyName", "company", "company_name")
+
+
+def _extract_salary(item: dict[str, Any]) -> str | None:
+    salary = _first_text(item, "salary", "salaryInfo", "compensation")
+    if salary:
+        return salary
+    salary_insights = item.get("salaryInsights")
+    if isinstance(salary_insights, dict) and salary_insights:
+        return str(salary_insights)
+    return None
+
+
+def _extract_remote(item: dict[str, Any]) -> bool | None:
+    for key in ("workRemoteAllowed", "remote", "isRemote", "remoteAllowed"):
+        value = item.get(key)
+        if isinstance(value, bool):
+            return value
+
+    workplace_types = item.get("workplaceTypes")
+    if isinstance(workplace_types, list):
+        normalized_types = {str(value).lower() for value in workplace_types}
+        if "remote" in normalized_types:
+            return True
+        if normalized_types.intersection({"hybrid", "on-site", "onsite"}):
+            return False
+
+    workplace = _first_text(item, "workplaceType", "workType", "workplace")
+    if workplace:
+        normalized = workplace.lower()
+        if "remote" in normalized or "à distance" in normalized:
+            return True
+        if "on-site" in normalized or "onsite" in normalized or "hybrid" in normalized:
+            return False
+    return None
+
+
+def _extract_posted_at(item: dict[str, Any]) -> datetime | None:
+    timestamp = item.get("postedAtTimestamp")
+    if isinstance(timestamp, int | float):
+        return datetime.fromtimestamp(timestamp / 1000, tz=UTC)
+
+    value = _first_text(item, "postedAt", "posted_at", "listedAt", "createdAt")
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _first_text(item: dict[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, int | float):
+            return str(value)
+    return None

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,170 @@
+from datetime import UTC, datetime
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from linkedin_scrapper.models import Base, CandidateProfile, Job, SearchRun, SearchRunJob
+from linkedin_scrapper.services.jobs import normalize_apify_job, persist_apify_jobs
+
+
+def test_normalize_apify_job_maps_real_linkedin_payload_fields() -> None:
+    item = {
+        "id": "4368302805",
+        "link": "https://fr.linkedin.com/jobs/view/fullstack-software-engineer-at-alan-4368302805",
+        "title": "Fullstack Software Engineer (x/f/m) - Ops AI Platform",
+        "companyName": "Alan",
+        "location": "Montpellier, Occitanie, France",
+        "descriptionHtml": "<strong>HTML description</strong>",
+        "descriptionText": "Plain text description",
+        "applyUrl": "https://jobs.ashbyhq.com/alan/7094b0ed",
+        "salary": "",
+        "postedAt": "2026-04-28T14:21:25.000Z",
+        "postedAtTimestamp": 1777386085000,
+        "workplaceTypes": ["Hybrid"],
+        "workRemoteAllowed": False,
+        "standardizedTitle": "Artificial Intelligence Engineer",
+        "expireAt": 1783003175000,
+    }
+
+    normalized = normalize_apify_job(item)
+
+    assert normalized == {
+        "external_id": "4368302805",
+        "title": "Fullstack Software Engineer (x/f/m) - Ops AI Platform",
+        "company": "Alan",
+        "location": "Montpellier, Occitanie, France",
+        "url": "https://fr.linkedin.com/jobs/view/fullstack-software-engineer-at-alan-4368302805",
+        "apply_url": "https://jobs.ashbyhq.com/alan/7094b0ed",
+        "description": "Plain text description",
+        "salary": None,
+        "remote": False,
+        "posted_at": datetime(2026, 4, 28, 14, 21, 25, tzinfo=UTC),
+        "raw_payload": item,
+    }
+    assert normalized["raw_payload"]["expireAt"] == 1783003175000
+
+
+def test_normalize_apify_job_rebuilds_url_from_id_when_missing() -> None:
+    normalized = normalize_apify_job(
+        {
+            "id": "123",
+            "title": "Backend Engineer",
+            "companyName": "Example",
+        }
+    )
+
+    assert normalized["url"] == "https://www.linkedin.com/jobs/view/123"
+    assert normalized["external_id"] == "123"
+
+
+def test_normalize_apify_job_ignores_unidentifiable_items() -> None:
+    assert normalize_apify_job({"title": "No identifiers"}) is None
+
+
+def test_persist_apify_jobs_deduplicates_by_external_id() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        first_run = _create_search_run(session, "first")
+        second_run = _create_search_run(session, "second")
+
+        assert persist_apify_jobs(session, first_run, [_item("123", title="Old")]) == 1
+        assert persist_apify_jobs(session, second_run, [_item("123", title="Updated")]) == 1
+        session.commit()
+
+        jobs = session.scalars(select(Job)).all()
+        assert len(jobs) == 1
+        assert jobs[0].title == "Updated"
+        assert len(session.scalars(select(SearchRunJob)).all()) == 2
+
+
+def test_persist_apify_jobs_deduplicates_by_url() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        search_run = _create_search_run(session, "url")
+        session.add(
+            Job(
+                title="Existing",
+                url="https://www.linkedin.com/jobs/view/456",
+            )
+        )
+        session.commit()
+
+        persist_apify_jobs(
+            session,
+            search_run,
+            [
+                {
+                    "title": "Updated",
+                    "link": "https://www.linkedin.com/jobs/view/456",
+                    "companyName": "Example",
+                }
+            ],
+        )
+        session.commit()
+
+        jobs = session.scalars(select(Job)).all()
+        assert len(jobs) == 1
+        assert jobs[0].title == "Updated"
+        assert jobs[0].company == "Example"
+
+
+def test_persist_apify_jobs_deduplicates_by_apply_url_and_enriches_linkedin_url() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        search_run = _create_search_run(session, "apply")
+        session.add(
+            Job(
+                title="Existing",
+                url="https://jobs.ashbyhq.com/alan/abc",
+                apply_url="https://jobs.ashbyhq.com/alan/abc",
+            )
+        )
+        session.commit()
+
+        persist_apify_jobs(
+            session,
+            search_run,
+            [
+                {
+                    "title": "Updated",
+                    "link": "https://www.linkedin.com/jobs/view/789",
+                    "applyUrl": "https://jobs.ashbyhq.com/alan/abc",
+                }
+            ],
+        )
+        session.commit()
+
+        job = session.scalars(select(Job)).one()
+        assert job.title == "Updated"
+        assert job.url == "https://www.linkedin.com/jobs/view/789"
+        assert job.apply_url == "https://jobs.ashbyhq.com/alan/abc"
+        assert len(session.scalars(select(SearchRunJob)).all()) == 1
+
+
+def _create_search_run(session: Session, suffix: str) -> SearchRun:
+    profile = CandidateProfile(cv_text="Python AI engineer")
+    search_run = SearchRun(
+        candidate_profile=profile,
+        query=f"AI Engineer {suffix}",
+        linkedin_url=f"https://www.linkedin.com/jobs/search/?keywords=AI+Engineer+{suffix}",
+        actor_name="curious_coder/linkedin-jobs-scraper",
+    )
+    session.add(search_run)
+    session.commit()
+    session.refresh(search_run)
+    return search_run
+
+
+def _item(external_id: str, title: str) -> dict:
+    return {
+        "id": external_id,
+        "title": title,
+        "link": f"https://www.linkedin.com/jobs/view/{external_id}",
+        "companyName": "Example",
+    }


### PR DESCRIPTION
## Summary
- Extract Apify job normalization and persistence into a dedicated jobs service.
- Map the real LinkedIn Jobs payload fields, including `link`, `descriptionText`, `applyUrl`, `postedAtTimestamp`, `workplaceTypes`, and `workRemoteAllowed`.
- Deduplicate jobs by `external_id`, then `url`, then `apply_url`, while preserving `raw_payload`.
- Keep Apify focused on Actor execution and dataset retrieval.
- Restore prompt rules expected by the current test suite.

## Notes
- `expireAt` is preserved in `raw_payload`; it is not treated as a reliable application deadline.

## Validation
- `PYTHONPATH=src /Volumes/SSD/SSD_Documents/linkedin_scrapper/.venv/bin/pytest`
- `/Volumes/SSD/SSD_Documents/linkedin_scrapper/.venv/bin/ruff check .`
- `PYTHONPATH=src /Volumes/SSD/SSD_Documents/linkedin_scrapper/.venv/bin/python -m compileall main.py src tests`

Closes #7