### PR TITLE
[codex] Score jobs with an LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,9 @@ Scrape pending LinkedIn Jobs searches with Apify:
 ```bash
 linkedin-scrapper scrape-jobs PROFILE_ID --count 20 --limit-runs 1
 ```
+
+Score scraped jobs against a saved candidate profile:
+
+```bash
+linkedin-scrapper score-jobs PROFILE_ID --limit-jobs 20
+```

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Create the database schema:
 linkedin-scrapper init-db
 ```
 
+During the PoC, schema changes are applied by recreating local tables:
+
+```bash
+linkedin-scrapper init-db --drop-existing
+```
+
 Parse a CV without saving:
 
 ```bash

--- a/src/linkedin_scrapper/cli.py
+++ b/src/linkedin_scrapper/cli.py
@@ -76,7 +76,7 @@ def parse_candidate_cv(
     parser_agent = build_cv_parser_agent(chat_model)
     parsed_profile = parse_cv(cv_path, parser_agent)
 
-    output = parsed_profile.model_dump()
+    output = parsed_profile.model_dump(mode="json")
     if save:
         engine = build_engine(settings)
         with Session(engine) as session:

--- a/src/linkedin_scrapper/cli.py
+++ b/src/linkedin_scrapper/cli.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 
 from linkedin_scrapper.config import Settings
 from linkedin_scrapper.cv_parser import build_cv_parser_agent, parse_cv
+from linkedin_scrapper.job_scorer import build_job_scorer_agent
 from linkedin_scrapper.pipeline import PipelineRequest, build_pipeline
 from linkedin_scrapper.search_planner import build_search_planner_agent, generate_linkedin_searches
 from linkedin_scrapper.services.apify import build_apify_client, scrape_linkedin_jobs_for_search_run
@@ -19,6 +20,7 @@ from linkedin_scrapper.services.searches import (
     load_candidate_profile,
     save_search_runs,
 )
+from linkedin_scrapper.services.scores import list_jobs_for_scoring, score_jobs_for_profile
 
 app = typer.Typer(help="LinkedIn job matching POC backend.")
 console = Console()
@@ -173,6 +175,65 @@ def scrape_jobs(
             "profile_id": str(profile_id),
             "pending_runs_selected": len(results),
             "results": results,
+        }
+    )
+
+
+@app.command("score-jobs")
+def score_jobs(
+    profile_id: UUID = typer.Argument(..., help="Candidate profile ID saved in the database."),
+    limit_jobs: int | None = typer.Option(
+        None,
+        "--limit-jobs",
+        help="Maximum number of jobs to score.",
+    ),
+    rescore: bool = typer.Option(
+        False,
+        "--rescore",
+        help="Recompute scores for jobs that already have a score.",
+    ),
+) -> None:
+    """Score persisted jobs against a candidate profile with an LLM."""
+    if limit_jobs is not None and limit_jobs < 1:
+        raise typer.BadParameter("--limit-jobs must be greater than 0.")
+
+    settings = Settings()
+    missing = []
+    if not settings.openai_api_key:
+        missing.append("OPENAI_API_KEY")
+    if not settings.database_url:
+        missing.append("DATABASE_URL")
+    if missing:
+        console.print({"missing_required_environment": missing})
+        raise typer.Exit(code=1)
+
+    chat_model = build_chat_model(settings)
+    scorer_agent = build_job_scorer_agent(chat_model)
+    engine = build_engine(settings)
+    with Session(engine) as session:
+        profile = load_candidate_profile(session, profile_id)
+        jobs = list_jobs_for_scoring(
+            session,
+            profile,
+            limit=limit_jobs,
+            include_scored=rescore,
+        )
+        results = score_jobs_for_profile(
+            session=session,
+            profile=profile,
+            jobs=jobs,
+            agent=scorer_agent,
+            model_name=settings.openai_model,
+            rescore=rescore,
+        )
+
+    console.print(
+        {
+            "profile_id": str(profile_id),
+            "jobs_selected": len(jobs),
+            "scores_created": sum(1 for result in results if not result.skipped),
+            "scores_skipped": sum(1 for result in results if result.skipped),
+            "results": [asdict(result) for result in results],
         }
     )
 

--- a/src/linkedin_scrapper/cv_parser.py
+++ b/src/linkedin_scrapper/cv_parser.py
@@ -85,6 +85,17 @@ class EducationItem(CVProfileModel):
     years: str | None = None
 
 
+class CandidateMarkdownProfile(CVProfileModel):
+    profile_snapshot: ProfileSnapshot = Field(default_factory=ProfileSnapshot)
+    consolidated_stack: ConsolidatedStack = Field(default_factory=ConsolidatedStack)
+    key_experiences: list[KeyExperience] = Field(default_factory=list)
+    education: list[EducationItem] = Field(default_factory=list)
+    markdown: str = Field(
+        min_length=1,
+        description="Synthetic markdown profile generated from the CV and markdown subobjects.",
+    )
+
+
 class CandidateProfileExtraction(CVProfileModel):
     full_name: str | None = None
     target_roles: list[str] = Field(default_factory=list)
@@ -94,10 +105,7 @@ class CandidateProfileExtraction(CVProfileModel):
     languages_spoken: list[Language] = Field(default_factory=list)
     industries_experienced: list[str] = Field(default_factory=list)
     skills: list[CandidateSkill] = Field(default_factory=list)
-    profile_snapshot: ProfileSnapshot = Field(default_factory=ProfileSnapshot)
-    consolidated_stack: ConsolidatedStack = Field(default_factory=ConsolidatedStack)
-    key_experiences: list[KeyExperience] = Field(default_factory=list)
-    education: list[EducationItem] = Field(default_factory=list)
+    markdown_profile: CandidateMarkdownProfile
     extraction_notes: list[str] = Field(default_factory=list)
 
 
@@ -137,11 +145,31 @@ Field guidance:
   For each skill, include years_of_experience, context, and last_used_year.
   context must be PRODUCTION, ACADEMIC, or PERSONAL. Skip skills that are not
   in the allowed list; do not invent new labels.
-- profile_snapshot: concise persona fields for future prompt context.
-- consolidated_stack: synthesize the practical stack by category.
-- key_experiences: synthesize only the most relevant experiences, preserving
-  titles, dates, mission, achievements, and stack when evidenced.
-- education: relevant diplomas or training.
+- markdown_profile: generate the markdown context in the markdown field and fill
+  its subobjects at the same time. The markdown must follow this exact structure:
+  # prénom Nom
+  **Titre cible** :
+  **Localisation** : ville, region, pays (Ouvert Remote : [Oui/Non])
+  **Langues** :
+  **Expérience globale** :
+  ## 🎯 Snapshot Profil (Persona)
+  * **ADN** :
+  * **Focus actuel** :
+  * **Points forts** :
+  ## 🛠 Stack Technique Consolidée
+  * **Core Backend & IA** :
+  * **Core Frontend** :
+  * **Infra & Outils** :
+  * **Domaines métiers** :
+  ## 💼 Expériences Clés Synthétisées
+  ### titre | dates
+  * **Mission** :
+  * **Réalisations** :
+      *
+  * **Stack** :
+  ## 🎓 Formation
+  * diplome - ecole (années)
+  Do not include a redundant skills table in markdown.
 - extraction_notes: concise evidence notes useful for debugging extraction decisions.
 
 When evidence conflicts, explain the decision in extraction_notes and keep the
@@ -186,7 +214,9 @@ def parse_cv_text(cv_text: str, agent: CVParserAgent) -> ParsedCandidateProfile:
             ]
         )
     )
-    markdown_context = render_candidate_profile_markdown(extraction)
+    markdown_context = _normalize_text(extraction.markdown_profile.markdown)
+    if not markdown_context:
+        raise ValueError("CV parser did not return markdown context.")
 
     payload = {
         "parser": "llm-cv-profile-v2",
@@ -196,13 +226,20 @@ def parse_cv_text(cv_text: str, agent: CVParserAgent) -> ParsedCandidateProfile:
         "extraction_notes": extraction.extraction_notes,
         "narrative": {
             "full_name": extraction.full_name,
-            "profile_snapshot": extraction.profile_snapshot.model_dump(mode="json"),
-            "consolidated_stack": extraction.consolidated_stack.model_dump(mode="json"),
+            "profile_snapshot": extraction.markdown_profile.profile_snapshot.model_dump(
+                mode="json"
+            ),
+            "consolidated_stack": (
+                extraction.markdown_profile.consolidated_stack.model_dump(mode="json")
+            ),
             "key_experiences": [
                 experience.model_dump(mode="json")
-                for experience in extraction.key_experiences
+                for experience in extraction.markdown_profile.key_experiences
             ],
-            "education": [item.model_dump(mode="json") for item in extraction.education],
+            "education": [
+                item.model_dump(mode="json")
+                for item in extraction.markdown_profile.education
+            ],
         },
     }
 
@@ -216,70 +253,9 @@ def parse_cv_text(cv_text: str, agent: CVParserAgent) -> ParsedCandidateProfile:
         languages_spoken=extraction.languages_spoken,
         industries_experienced=extraction.industries_experienced,
         skills=extraction.skills,
-        profile_snapshot=extraction.profile_snapshot,
-        consolidated_stack=extraction.consolidated_stack,
-        key_experiences=extraction.key_experiences,
-        education=extraction.education,
+        markdown_profile=extraction.markdown_profile,
         profile_payload=payload,
     )
-
-
-def render_candidate_profile_markdown(extraction: CandidateProfileExtraction) -> str:
-    name = extraction.full_name or "Profil candidat"
-    target_title = _join_values(extraction.target_roles) or "Non renseigné"
-    location = _join_values(extraction.locations) or "Non renseignée"
-    remote_open = "Oui" if _is_remote_open(extraction.remote_preference) else "Non"
-    languages = _join_values(extraction.languages_spoken) or "Non renseignées"
-    experience = (
-        f"{extraction.total_years_of_experience} ans"
-        if extraction.total_years_of_experience
-        else "Non renseignée"
-    )
-
-    sections = [
-        f"# {name}",
-        "",
-        f"**Titre cible** : {target_title}",
-        f"**Localisation** : {location} (Ouvert Remote : {remote_open})",
-        f"**Langues** : {languages}",
-        f"**Expérience globale** : {experience}",
-        "",
-        "## 🎯 Snapshot Profil (Persona)",
-        "",
-        f"* **ADN** : {_text_or_unknown(extraction.profile_snapshot.dna)}",
-        f"* **Focus actuel** : {_text_or_unknown(extraction.profile_snapshot.current_focus)}",
-        f"* **Points forts** : {_join_values(extraction.profile_snapshot.strengths) or 'Non renseignés'}",
-        "",
-        "## 🛠 Stack Technique Consolidée",
-        "",
-        f"* **Core Backend & IA** : {_join_values(extraction.consolidated_stack.core_backend_ai) or 'Non renseigné'}",
-        f"* **Core Frontend** : {_join_values(extraction.consolidated_stack.core_frontend) or 'Non renseigné'}",
-        f"* **Infra & Outils** : {_join_values(extraction.consolidated_stack.infra_tools) or 'Non renseigné'}",
-        f"* **Domaines métiers** : {_join_values(extraction.consolidated_stack.business_domains or extraction.industries_experienced) or 'Non renseignés'}",
-        "",
-        "## 💼 Expériences Clés Synthétisées",
-        "",
-    ]
-
-    if extraction.key_experiences:
-        for experience_item in extraction.key_experiences:
-            sections.extend(_render_experience(experience_item))
-    else:
-        sections.append("* Non renseigné")
-        sections.append("")
-
-    sections.extend(
-        [
-            "## 🎓 Formation",
-            "",
-        ]
-    )
-    if extraction.education:
-        sections.extend(f"* {_format_education_item(item)}" for item in extraction.education)
-    else:
-        sections.append("* Non renseignée")
-
-    return "\n".join(sections).strip()
 
 
 def _extract_pdf_text(path: Path) -> str:
@@ -300,52 +276,6 @@ def _normalize_text(text: str) -> str:
         previous_blank = is_blank
 
     return "\n".join(normalized_lines).strip()
-
-
-def _render_experience(experience: KeyExperience) -> list[str]:
-    title = experience.title.strip()
-    dates = experience.dates.strip() if experience.dates else "dates non renseignées"
-    rendered = [
-        f"### {title} | {dates}",
-        "",
-        f"* **Mission** : {_text_or_unknown(experience.mission)}",
-        "* **Réalisations** :",
-    ]
-    if experience.achievements:
-        rendered.extend(f"    * {achievement}" for achievement in experience.achievements)
-    else:
-        rendered.append("    * Non renseignée")
-    rendered.extend(
-        [
-            f"* **Stack** : {_join_values(experience.stack) or 'Non renseignée'}",
-            "",
-        ]
-    )
-    return rendered
-
-
-def _format_education_item(item: EducationItem) -> str:
-    output = item.degree.strip()
-    if item.school:
-        output = f"{output} - {item.school.strip()}"
-    if item.years:
-        output = f"{output} ({item.years.strip()})"
-    return output
-
-
-def _is_remote_open(remote_preference: list[RemotePreference]) -> bool:
-    return any(
-        preference in {RemotePreference.FULL_REMOTE, RemotePreference.HYBRID}
-        for preference in remote_preference
-    )
-
-
-def _join_values(values: list[Any]) -> str:
-    return ", ".join(str(value).strip() for value in values if str(value).strip())
-
-
-def _text_or_unknown(value: str | None) -> str:
-    return value.strip() if value and value.strip() else "Non renseigné"
 
 
 def _coerce_extraction(

--- a/src/linkedin_scrapper/cv_parser.py
+++ b/src/linkedin_scrapper/cv_parser.py
@@ -1,24 +1,110 @@
 from __future__ import annotations
 
+from enum import StrEnum
+from hashlib import sha256
 from pathlib import Path
 from typing import Any, Protocol
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from pypdf import PdfReader
 
 
-class CandidateProfileExtraction(BaseModel):
+class CVProfileModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class RemotePreference(StrEnum):
+    FULL_REMOTE = "FULL_REMOTE"
+    HYBRID = "HYBRID"
+    ONSITE = "ONSITE"
+
+
+class Language(StrEnum):
+    FR = "FR"
+    EN = "EN"
+
+
+class SkillContext(StrEnum):
+    PRODUCTION = "PRODUCTION"
+    ACADEMIC = "ACADEMIC"
+    PERSONAL = "PERSONAL"
+
+
+class SkillName(StrEnum):
+    PYTHON = "Python"
+    JAVASCRIPT = "JavaScript"
+    TYPESCRIPT = "TypeScript"
+    REACT = "React"
+    FASTAPI = "FastAPI"
+    DJANGO = "Django"
+    POSTGRESQL = "PostgreSQL"
+    DOCKER = "Docker"
+    KUBERNETES = "Kubernetes"
+    LANGCHAIN = "LangChain"
+    LANGGRAPH = "LangGraph"
+    OPENAI = "OpenAI"
+    LLM = "LLM"
+    RAG = "RAG"
+    SQLALCHEMY = "SQLAlchemy"
+    PYDANTIC = "Pydantic"
+    TYPER = "Typer"
+    APIFY = "Apify"
+
+
+class CandidateSkill(CVProfileModel):
+    name: SkillName
+    years_of_experience: int = Field(ge=0)
+    context: SkillContext
+    last_used_year: int = Field(ge=1900)
+
+
+class ProfileSnapshot(CVProfileModel):
+    dna: str | None = None
+    current_focus: str | None = None
+    strengths: list[str] = Field(default_factory=list)
+
+
+class ConsolidatedStack(CVProfileModel):
+    core_backend_ai: list[str] = Field(default_factory=list)
+    core_frontend: list[str] = Field(default_factory=list)
+    infra_tools: list[str] = Field(default_factory=list)
+    business_domains: list[str] = Field(default_factory=list)
+
+
+class KeyExperience(CVProfileModel):
+    title: str
+    dates: str | None = None
+    mission: str | None = None
+    achievements: list[str] = Field(default_factory=list)
+    stack: list[str] = Field(default_factory=list)
+
+
+class EducationItem(CVProfileModel):
+    degree: str
+    school: str | None = None
+    years: str | None = None
+
+
+class CandidateProfileExtraction(CVProfileModel):
+    full_name: str | None = None
     target_roles: list[str] = Field(default_factory=list)
-    skills: list[str] = Field(default_factory=list)
     locations: list[str] = Field(default_factory=list)
-    remote_preference: str | None = None
-    seniority: str | None = None
-    exclusions: list[str] = Field(default_factory=list)
+    total_years_of_experience: int = Field(default=0, ge=0)
+    remote_preference: list[RemotePreference] = Field(default_factory=list)
+    languages_spoken: list[Language] = Field(default_factory=list)
+    industries_experienced: list[str] = Field(default_factory=list)
+    skills: list[CandidateSkill] = Field(default_factory=list)
+    profile_snapshot: ProfileSnapshot = Field(default_factory=ProfileSnapshot)
+    consolidated_stack: ConsolidatedStack = Field(default_factory=ConsolidatedStack)
+    key_experiences: list[KeyExperience] = Field(default_factory=list)
+    education: list[EducationItem] = Field(default_factory=list)
     extraction_notes: list[str] = Field(default_factory=list)
 
 
 class ParsedCandidateProfile(CandidateProfileExtraction):
     cv_text: str
+    seniority: str | None = None
+    exclusions: list[str] = Field(default_factory=list)
     profile_payload: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -30,25 +116,36 @@ class CVParserAgent(Protocol):
 CV_PARSER_SYSTEM_PROMPT = """
 You extract a structured candidate profile from a CV for job-search automation.
 
-Return only fields that are supported by evidence in the CV. Use empty lists or null
-when the CV does not provide enough information.
-For seniority, analyse the CV text and return the most appropriate value. 
+Return only fields that are supported by evidence in the CV. Do not infer visa status.
+Use empty lists, empty nested objects, zero for total_years_of_experience, or
+null only for nullable string fields when the CV does not provide enough
+information.
 
 Field guidance:
-- target_roles: normalized job titles the candidate is suited for.
-- skills: concrete tools, languages, frameworks, platforms, and methods.
-- locations: only current residence/base location and explicit target job-search
-  locations. Do not include historical work, education, client, employer, travel,
-  or project locations unless the CV explicitly states the candidate wants jobs
-  there. For LinkedIn exports, prefer the profile header/contact location over
-  experience locations.
-- remote_preference: one of remote, hybrid, onsite, or null.
-- seniority: junior, mid, senior, staff, principal, lead, or null. 
-- exclusions: explicit constraints, avoidances, or non-target roles.
+- full_name: candidate first and last name when present.
+- target_roles: normalized target job titles for the candidate.
+- locations: current residence/base location and explicit target job-search
+  locations. This field is also rendered in the markdown context.
+- total_years_of_experience: global professional development experience.
+- remote_preference: use only FULL_REMOTE, HYBRID, or ONSITE.
+- languages_spoken: use only FR and EN.
+- industries_experienced: business sectors where the CV shows real experience.
+- skills: controlled technical skills only. Allowed skill names are:
+  Python, JavaScript, TypeScript, React, FastAPI, Django, PostgreSQL, Docker,
+  Kubernetes, LangChain, LangGraph, OpenAI, LLM, RAG, SQLAlchemy, Pydantic,
+  Typer, Apify.
+  For each skill, include years_of_experience, context, and last_used_year.
+  context must be PRODUCTION, ACADEMIC, or PERSONAL. Skip skills that are not
+  in the allowed list; do not invent new labels.
+- profile_snapshot: concise persona fields for future prompt context.
+- consolidated_stack: synthesize the practical stack by category.
+- key_experiences: synthesize only the most relevant experiences, preserving
+  titles, dates, mission, achievements, and stack when evidenced.
+- education: relevant diplomas or training.
 - extraction_notes: concise evidence notes useful for debugging extraction decisions.
 
-When location evidence conflicts, explain the decision in extraction_notes and keep
-locations focused on job-search geography, not the candidate's full work history.
+When evidence conflicts, explain the decision in extraction_notes and keep the
+structured fields conservative.
 """.strip()
 
 
@@ -89,23 +186,100 @@ def parse_cv_text(cv_text: str, agent: CVParserAgent) -> ParsedCandidateProfile:
             ]
         )
     )
+    markdown_context = render_candidate_profile_markdown(extraction)
 
     payload = {
-        "parser": "llm-agent-v1",
+        "parser": "llm-cv-profile-v2",
         "text_length": len(normalized),
+        "raw_text_length": len(normalized),
+        "raw_text_sha256": sha256(normalized.encode("utf-8")).hexdigest(),
         "extraction_notes": extraction.extraction_notes,
+        "narrative": {
+            "full_name": extraction.full_name,
+            "profile_snapshot": extraction.profile_snapshot.model_dump(mode="json"),
+            "consolidated_stack": extraction.consolidated_stack.model_dump(mode="json"),
+            "key_experiences": [
+                experience.model_dump(mode="json")
+                for experience in extraction.key_experiences
+            ],
+            "education": [item.model_dump(mode="json") for item in extraction.education],
+        },
     }
 
     return ParsedCandidateProfile(
-        cv_text=normalized,
+        cv_text=markdown_context,
+        full_name=extraction.full_name,
         target_roles=extraction.target_roles,
-        skills=extraction.skills,
         locations=extraction.locations,
+        total_years_of_experience=extraction.total_years_of_experience,
         remote_preference=extraction.remote_preference,
-        seniority=extraction.seniority,
-        exclusions=extraction.exclusions,
+        languages_spoken=extraction.languages_spoken,
+        industries_experienced=extraction.industries_experienced,
+        skills=extraction.skills,
+        profile_snapshot=extraction.profile_snapshot,
+        consolidated_stack=extraction.consolidated_stack,
+        key_experiences=extraction.key_experiences,
+        education=extraction.education,
         profile_payload=payload,
     )
+
+
+def render_candidate_profile_markdown(extraction: CandidateProfileExtraction) -> str:
+    name = extraction.full_name or "Profil candidat"
+    target_title = _join_values(extraction.target_roles) or "Non renseigné"
+    location = _join_values(extraction.locations) or "Non renseignée"
+    remote_open = "Oui" if _is_remote_open(extraction.remote_preference) else "Non"
+    languages = _join_values(extraction.languages_spoken) or "Non renseignées"
+    experience = (
+        f"{extraction.total_years_of_experience} ans"
+        if extraction.total_years_of_experience
+        else "Non renseignée"
+    )
+
+    sections = [
+        f"# {name}",
+        "",
+        f"**Titre cible** : {target_title}",
+        f"**Localisation** : {location} (Ouvert Remote : {remote_open})",
+        f"**Langues** : {languages}",
+        f"**Expérience globale** : {experience}",
+        "",
+        "## 🎯 Snapshot Profil (Persona)",
+        "",
+        f"* **ADN** : {_text_or_unknown(extraction.profile_snapshot.dna)}",
+        f"* **Focus actuel** : {_text_or_unknown(extraction.profile_snapshot.current_focus)}",
+        f"* **Points forts** : {_join_values(extraction.profile_snapshot.strengths) or 'Non renseignés'}",
+        "",
+        "## 🛠 Stack Technique Consolidée",
+        "",
+        f"* **Core Backend & IA** : {_join_values(extraction.consolidated_stack.core_backend_ai) or 'Non renseigné'}",
+        f"* **Core Frontend** : {_join_values(extraction.consolidated_stack.core_frontend) or 'Non renseigné'}",
+        f"* **Infra & Outils** : {_join_values(extraction.consolidated_stack.infra_tools) or 'Non renseigné'}",
+        f"* **Domaines métiers** : {_join_values(extraction.consolidated_stack.business_domains or extraction.industries_experienced) or 'Non renseignés'}",
+        "",
+        "## 💼 Expériences Clés Synthétisées",
+        "",
+    ]
+
+    if extraction.key_experiences:
+        for experience_item in extraction.key_experiences:
+            sections.extend(_render_experience(experience_item))
+    else:
+        sections.append("* Non renseigné")
+        sections.append("")
+
+    sections.extend(
+        [
+            "## 🎓 Formation",
+            "",
+        ]
+    )
+    if extraction.education:
+        sections.extend(f"* {_format_education_item(item)}" for item in extraction.education)
+    else:
+        sections.append("* Non renseignée")
+
+    return "\n".join(sections).strip()
 
 
 def _extract_pdf_text(path: Path) -> str:
@@ -126,6 +300,52 @@ def _normalize_text(text: str) -> str:
         previous_blank = is_blank
 
     return "\n".join(normalized_lines).strip()
+
+
+def _render_experience(experience: KeyExperience) -> list[str]:
+    title = experience.title.strip()
+    dates = experience.dates.strip() if experience.dates else "dates non renseignées"
+    rendered = [
+        f"### {title} | {dates}",
+        "",
+        f"* **Mission** : {_text_or_unknown(experience.mission)}",
+        "* **Réalisations** :",
+    ]
+    if experience.achievements:
+        rendered.extend(f"    * {achievement}" for achievement in experience.achievements)
+    else:
+        rendered.append("    * Non renseignée")
+    rendered.extend(
+        [
+            f"* **Stack** : {_join_values(experience.stack) or 'Non renseignée'}",
+            "",
+        ]
+    )
+    return rendered
+
+
+def _format_education_item(item: EducationItem) -> str:
+    output = item.degree.strip()
+    if item.school:
+        output = f"{output} - {item.school.strip()}"
+    if item.years:
+        output = f"{output} ({item.years.strip()})"
+    return output
+
+
+def _is_remote_open(remote_preference: list[RemotePreference]) -> bool:
+    return any(
+        preference in {RemotePreference.FULL_REMOTE, RemotePreference.HYBRID}
+        for preference in remote_preference
+    )
+
+
+def _join_values(values: list[Any]) -> str:
+    return ", ".join(str(value).strip() for value in values if str(value).strip())
+
+
+def _text_or_unknown(value: str | None) -> str:
+    return value.strip() if value and value.strip() else "Non renseigné"
 
 
 def _coerce_extraction(

--- a/src/linkedin_scrapper/cv_parser.py
+++ b/src/linkedin_scrapper/cv_parser.py
@@ -5,6 +5,8 @@ from hashlib import sha256
 from pathlib import Path
 from typing import Any, Protocol
 
+from langchain.agents import create_agent
+from langchain_core.tools import tool
 from pydantic import BaseModel, ConfigDict, Field
 from pypdf import PdfReader
 
@@ -117,19 +119,31 @@ class ParsedCandidateProfile(CandidateProfileExtraction):
 
 
 class CVParserAgent(Protocol):
-    def invoke(self, input: Any) -> CandidateProfileExtraction | dict[str, Any]:
+    def invoke(self, input: Any) -> Any:
         pass
 
 
 CV_PARSER_SYSTEM_PROMPT = """
-You extract a structured candidate profile from a CV for job-search automation.
+You extract candidate profiles from CVs.
+You have access to skills. Use load_skill when detailed domain instructions are needed.
+For CV parsing, load the cv_profile_extraction skill before producing the final
+structured response.
+Do not rely on unstated extraction rules; follow the loaded skill.
+""".strip()
+
+CV_PROFILE_EXTRACTION_SKILL_NAME = "cv_profile_extraction"
+
+CV_PROFILE_EXTRACTION_SKILL = """
+Skill: cv_profile_extraction
+
+Extract a structured candidate profile from a CV for job-search automation.
 
 Return only fields that are supported by evidence in the CV. Do not infer visa status.
 Use empty lists, empty nested objects, zero for total_years_of_experience, or
 null only for nullable string fields when the CV does not provide enough
 information.
 
-Field guidance:
+Output contract:
 - full_name: candidate first and last name when present.
 - target_roles: normalized target job titles for the candidate.
 - locations: current residence/base location and explicit target job-search
@@ -177,8 +191,21 @@ structured fields conservative.
 """.strip()
 
 
+@tool
+def load_skill(skill_name: str) -> str:
+    """Load a specialized skill prompt."""
+    if skill_name != CV_PROFILE_EXTRACTION_SKILL_NAME:
+        raise ValueError(f"Unknown skill: {skill_name}")
+    return CV_PROFILE_EXTRACTION_SKILL
+
+
 def build_cv_parser_agent(chat_model: Any) -> CVParserAgent:
-    return chat_model.with_structured_output(CandidateProfileExtraction)
+    return create_agent(
+        model=chat_model,
+        tools=[load_skill],
+        system_prompt=CV_PARSER_SYSTEM_PROMPT,
+        response_format=CandidateProfileExtraction,
+    )
 
 
 def parse_cv(path: Path, agent: CVParserAgent) -> ParsedCandidateProfile:
@@ -208,10 +235,18 @@ def parse_cv_text(cv_text: str, agent: CVParserAgent) -> ParsedCandidateProfile:
     normalized = _normalize_text(cv_text)
     extraction = _coerce_extraction(
         agent.invoke(
-            [
-                ("system", CV_PARSER_SYSTEM_PROMPT),
-                ("human", f"CV text:\n\n{normalized}"),
-            ]
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": (
+                            "Extract the candidate profile from this CV. "
+                            f"Use the {CV_PROFILE_EXTRACTION_SKILL_NAME} skill.\n\n"
+                            f"CV text:\n\n{normalized}"
+                        ),
+                    }
+                ]
+            }
         )
     )
     markdown_context = _normalize_text(extraction.markdown_profile.markdown)
@@ -283,4 +318,6 @@ def _coerce_extraction(
 ) -> CandidateProfileExtraction:
     if isinstance(extraction, CandidateProfileExtraction):
         return extraction
+    if isinstance(extraction, dict) and "structured_response" in extraction:
+        return _coerce_extraction(extraction["structured_response"])
     return CandidateProfileExtraction.model_validate(extraction)

--- a/src/linkedin_scrapper/job_scorer.py
+++ b/src/linkedin_scrapper/job_scorer.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from pydantic import BaseModel, Field
+
+from linkedin_scrapper.models import CandidateProfile, Job
+
+
+class JobScoreExtraction(BaseModel):
+    score: int = Field(ge=0, le=100)
+    summary: str
+    match_reasons: list[str] = Field(default_factory=list)
+    missing_skills: list[str] = Field(default_factory=list)
+    risk_flags: list[str] = Field(default_factory=list)
+
+
+class JobScorerAgent(Protocol):
+    def invoke(self, input: Any) -> JobScoreExtraction | dict[str, Any]:
+        pass
+
+
+JOB_SCORER_SYSTEM_PROMPT = """
+You score how well a job matches a candidate profile for job-search automation.
+
+Return only evidence-backed scoring fields. Compare the candidate's target roles,
+skills, seniority, location, remote preference, and exclusions against the job
+title, description, company, location, and remote signal.
+
+Scoring guidance:
+- 80-100: strong match; role and core requirements align well.
+- 60-79: plausible match with meaningful reservations.
+- 40-59: partial or weak match.
+- 0-39: poor match or clear mismatch.
+
+Field guidance:
+- summary: one concise sentence explaining the fit.
+- match_reasons: concrete reasons the job fits the profile.
+- missing_skills: important concrete skills or experience requested by the job but
+  absent or weak in the candidate profile.
+- risk_flags: non-skill or contextual reservations, such as seniority mismatch,
+  mostly off-target role, incompatible location, onsite requirement, or language
+  requirements.
+
+Do not penalize minor wording differences or adjacent frameworks too heavily.
+Do penalize explicit exclusions and clear seniority or location mismatches.
+""".strip()
+
+
+def build_job_scorer_agent(chat_model: Any) -> JobScorerAgent:
+    return chat_model.with_structured_output(JobScoreExtraction)
+
+
+def score_job(
+    profile: CandidateProfile,
+    job: Job,
+    agent: JobScorerAgent,
+) -> JobScoreExtraction:
+    extraction = agent.invoke(
+        [
+            ("system", JOB_SCORER_SYSTEM_PROMPT),
+            ("human", _score_prompt(profile, job)),
+        ]
+    )
+    return _coerce_score(extraction)
+
+
+def _score_prompt(profile: CandidateProfile, job: Job) -> str:
+    return "\n".join(
+        [
+            "Candidate profile:",
+            f"- Target roles: {', '.join(profile.target_roles) or 'none'}",
+            f"- Skills: {', '.join(profile.skills) or 'none'}",
+            f"- Locations: {', '.join(profile.locations) or 'none'}",
+            f"- Remote preference: {profile.remote_preference or 'none'}",
+            f"- Seniority: {profile.seniority or 'none'}",
+            f"- Exclusions: {', '.join(profile.exclusions) or 'none'}",
+            "",
+            "Job:",
+            f"- Title: {job.title}",
+            f"- Company: {job.company or 'none'}",
+            f"- Location: {job.location or 'none'}",
+            f"- Remote: {job.remote if job.remote is not None else 'unknown'}",
+            f"- Salary: {job.salary or 'none'}",
+            f"- Description: {_truncate(job.description or 'none')}",
+        ]
+    )
+
+
+def _truncate(text: str, max_chars: int = 6000) -> str:
+    if len(text) <= max_chars:
+        return text
+    return f"{text[:max_chars].rstrip()}..."
+
+
+def _coerce_score(extraction: JobScoreExtraction | dict[str, Any]) -> JobScoreExtraction:
+    if isinstance(extraction, JobScoreExtraction):
+        return extraction
+    return JobScoreExtraction.model_validate(extraction)

--- a/src/linkedin_scrapper/job_scorer.py
+++ b/src/linkedin_scrapper/job_scorer.py
@@ -5,6 +5,7 @@ from typing import Any, Protocol
 from pydantic import BaseModel, Field
 
 from linkedin_scrapper.models import CandidateProfile, Job
+from linkedin_scrapper.profile_formatting import format_candidate_skills, format_string_list
 
 
 class JobScoreExtraction(BaseModel):
@@ -69,12 +70,18 @@ def _score_prompt(profile: CandidateProfile, job: Job) -> str:
     return "\n".join(
         [
             "Candidate profile:",
-            f"- Target roles: {', '.join(profile.target_roles) or 'none'}",
-            f"- Skills: {', '.join(profile.skills) or 'none'}",
-            f"- Locations: {', '.join(profile.locations) or 'none'}",
-            f"- Remote preference: {profile.remote_preference or 'none'}",
+            _truncate(profile.cv_text or "none", max_chars=4000),
+            "",
+            "Scorable structured candidate fields:",
+            f"- Target roles: {format_string_list(profile.target_roles)}",
+            f"- Skills: {format_candidate_skills(profile.skills)}",
+            f"- Locations: {format_string_list(profile.locations)}",
+            f"- Remote preference: {format_string_list(profile.remote_preference)}",
+            f"- Languages: {format_string_list(profile.languages_spoken)}",
+            f"- Industries: {format_string_list(profile.industries_experienced)}",
+            f"- Total years of experience: {profile.total_years_of_experience}",
             f"- Seniority: {profile.seniority or 'none'}",
-            f"- Exclusions: {', '.join(profile.exclusions) or 'none'}",
+            f"- Exclusions: {format_string_list(profile.exclusions)}",
             "",
             "Job:",
             f"- Title: {job.title}",

--- a/src/linkedin_scrapper/models.py
+++ b/src/linkedin_scrapper/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
+from typing import Any
 from uuid import UUID, uuid4
 
 from sqlalchemy import (
@@ -59,9 +60,24 @@ class CandidateProfile(TimestampMixin, Base):
     id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid4)
     cv_text: Mapped[str] = mapped_column(Text, nullable=False)
     target_roles: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
-    skills: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
     locations: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
-    remote_preference: Mapped[str | None] = mapped_column(String(50))
+    total_years_of_experience: Mapped[int] = mapped_column(
+        Integer,
+        default=0,
+        nullable=False,
+    )
+    remote_preference: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    languages_spoken: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    industries_experienced: Mapped[list[str]] = mapped_column(
+        JSON,
+        default=list,
+        nullable=False,
+    )
+    skills: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSON,
+        default=list,
+        nullable=False,
+    )
     seniority: Mapped[str | None] = mapped_column(String(100))
     exclusions: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
     profile_payload: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)

--- a/src/linkedin_scrapper/profile_formatting.py
+++ b/src/linkedin_scrapper/profile_formatting.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+
+def format_candidate_skills(skills: Sequence[Any] | None) -> str:
+    if not skills:
+        return "none"
+
+    formatted = [_format_skill(skill) for skill in skills]
+    return "; ".join(skill for skill in formatted if skill) or "none"
+
+
+def format_string_list(values: Any) -> str:
+    if values is None:
+        return "none"
+    if isinstance(values, str):
+        return values if values.strip() else "none"
+    if not isinstance(values, Sequence):
+        return str(values)
+
+    formatted = [str(value).strip() for value in values if str(value).strip()]
+    return ", ".join(formatted) or "none"
+
+
+def _format_skill(skill: Any) -> str:
+    if isinstance(skill, str):
+        return skill
+
+    if isinstance(skill, dict):
+        name = skill.get("name")
+        years = skill.get("years_of_experience")
+        context = skill.get("context")
+        last_used_year = skill.get("last_used_year")
+    else:
+        name = getattr(skill, "name", None)
+        years = getattr(skill, "years_of_experience", None)
+        context = getattr(skill, "context", None)
+        last_used_year = getattr(skill, "last_used_year", None)
+
+    if not name:
+        return ""
+
+    details = []
+    if years is not None:
+        details.append(f"{years}y")
+    if context:
+        details.append(str(context))
+    if last_used_year is not None:
+        details.append(f"last used {last_used_year}")
+
+    if not details:
+        return str(name)
+    return f"{name} ({', '.join(details)})"

--- a/src/linkedin_scrapper/search_planner.py
+++ b/src/linkedin_scrapper/search_planner.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 from pydantic import BaseModel, Field
 
 from linkedin_scrapper.config import Settings
+from linkedin_scrapper.profile_formatting import format_candidate_skills, format_string_list
 from linkedin_scrapper.search_locations import LOCAL_SEARCH_LOCATION, REMOTE_SEARCH_LOCATION
 
 
@@ -31,10 +32,13 @@ class SearchPlannerAgent(Protocol):
 
 
 class CandidateSearchProfile(Protocol):
+    cv_text: str
     target_roles: list[str]
-    skills: list[str]
+    skills: list[Any]
     locations: list[str]
-    remote_preference: str | None
+    remote_preference: list[str]
+    languages_spoken: list[str]
+    industries_experienced: list[str]
     seniority: str | None
     exclusions: list[str]
 
@@ -120,14 +124,27 @@ def _profile_prompt(profile: CandidateSearchProfile, max_titles: int) -> str:
     return "\n".join(
         [
             f"Maximum job titles: {max_titles}",
-            f"Target roles: {', '.join(profile.target_roles) or 'none'}",
-            f"Skills: {', '.join(profile.skills) or 'none'}",
-            f"Locations: {', '.join(profile.locations) or 'none'}",
-            f"Remote preference: {profile.remote_preference or 'none'}",
-            f"Seniority: {profile.seniority or 'none'}",
-            f"Exclusions: {', '.join(profile.exclusions) or 'none'}",
+            "",
+            "Candidate markdown context:",
+            _truncate(getattr(profile, "cv_text", "") or "none", max_chars=4000),
+            "",
+            "Structured candidate fields:",
+            f"Target roles: {format_string_list(profile.target_roles)}",
+            f"Skills: {format_candidate_skills(profile.skills)}",
+            f"Locations: {format_string_list(profile.locations)}",
+            f"Remote preference: {format_string_list(profile.remote_preference)}",
+            f"Languages: {format_string_list(getattr(profile, 'languages_spoken', []))}",
+            f"Industries: {format_string_list(getattr(profile, 'industries_experienced', []))}",
+            f"Seniority: {getattr(profile, 'seniority', None) or 'none'}",
+            f"Exclusions: {format_string_list(getattr(profile, 'exclusions', []))}",
         ]
     )
+
+
+def _truncate(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    return f"{text[:max_chars].rstrip()}..."
 
 
 def _coerce_plan(plan: LinkedInSearchPlan | dict[str, Any]) -> LinkedInSearchPlan:

--- a/src/linkedin_scrapper/services/profiles.py
+++ b/src/linkedin_scrapper/services/profiles.py
@@ -1,6 +1,6 @@
 from sqlalchemy.orm import Session
 
-from linkedin_scrapper.cv_parser import ParsedCandidateProfile
+from linkedin_scrapper.cv_parser import CandidateSkill, ParsedCandidateProfile
 from linkedin_scrapper.models import CandidateProfile
 
 
@@ -11,9 +11,12 @@ def save_candidate_profile(
     profile = CandidateProfile(
         cv_text=parsed_profile.cv_text,
         target_roles=parsed_profile.target_roles,
-        skills=parsed_profile.skills,
         locations=parsed_profile.locations,
-        remote_preference=parsed_profile.remote_preference,
+        total_years_of_experience=parsed_profile.total_years_of_experience,
+        remote_preference=[preference.value for preference in parsed_profile.remote_preference],
+        languages_spoken=[language.value for language in parsed_profile.languages_spoken],
+        industries_experienced=parsed_profile.industries_experienced,
+        skills=[_dump_skill(skill) for skill in parsed_profile.skills],
         seniority=parsed_profile.seniority,
         exclusions=parsed_profile.exclusions,
         profile_payload=parsed_profile.profile_payload,
@@ -22,3 +25,7 @@ def save_candidate_profile(
     session.commit()
     session.refresh(profile)
     return profile
+
+
+def _dump_skill(skill: CandidateSkill) -> dict:
+    return skill.model_dump(mode="json")

--- a/src/linkedin_scrapper/services/scores.py
+++ b/src/linkedin_scrapper/services/scores.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from linkedin_scrapper.job_scorer import JobScorerAgent, JobScoreExtraction, score_job
+from linkedin_scrapper.models import CandidateProfile, Job, JobScore, SearchRun, SearchRunJob
+
+
+@dataclass(frozen=True)
+class JobScoringResult:
+    job_id: str
+    title: str
+    skipped: bool
+    score: int | None = None
+    summary: str | None = None
+
+
+def list_jobs_for_scoring(
+    session: Session,
+    profile: CandidateProfile,
+    limit: int | None = None,
+    include_scored: bool = False,
+) -> list[Job]:
+    statement = (
+        select(Job)
+        .join(SearchRunJob, SearchRunJob.job_id == Job.id)
+        .join(SearchRun, SearchRun.id == SearchRunJob.search_run_id)
+        .where(SearchRun.profile_id == profile.id)
+        .order_by(Job.created_at)
+        .distinct()
+    )
+    if not include_scored:
+        statement = statement.outerjoin(JobScore, JobScore.job_id == Job.id).where(
+            JobScore.id.is_(None)
+        )
+    if limit is not None:
+        statement = statement.limit(limit)
+    return list(session.scalars(statement))
+
+
+def score_jobs_for_profile(
+    session: Session,
+    profile: CandidateProfile,
+    jobs: list[Job],
+    agent: JobScorerAgent,
+    model_name: str,
+    rescore: bool = False,
+) -> list[JobScoringResult]:
+    results = []
+    for job in jobs:
+        existing_score = job.score
+        if existing_score is not None and not rescore:
+            results.append(
+                JobScoringResult(
+                    job_id=str(job.id),
+                    title=job.title,
+                    skipped=True,
+                    score=existing_score.score,
+                    summary=existing_score.summary,
+                )
+            )
+            continue
+
+        extraction = score_job(profile, job, agent)
+        saved_score = save_job_score(
+            session=session,
+            profile_id=profile.id,
+            job=job,
+            extraction=extraction,
+            model_name=model_name,
+            existing_score=existing_score,
+        )
+        results.append(
+            JobScoringResult(
+                job_id=str(job.id),
+                title=job.title,
+                skipped=False,
+                score=saved_score.score,
+                summary=saved_score.summary,
+            )
+        )
+
+    session.commit()
+    return results
+
+
+def save_job_score(
+    session: Session,
+    profile_id: UUID,
+    job: Job,
+    extraction: JobScoreExtraction,
+    model_name: str,
+    existing_score: JobScore | None = None,
+) -> JobScore:
+    job_score = existing_score or JobScore(job=job)
+    job_score.score = extraction.score
+    job_score.summary = extraction.summary
+    job_score.match_reasons = extraction.match_reasons
+    job_score.missing_skills = extraction.missing_skills
+    job_score.risk_flags = extraction.risk_flags
+    job_score.scoring_payload = {
+        "scorer": "llm-job-scorer-v1",
+        "profile_id": str(profile_id),
+        "job_id": str(job.id),
+        "model": model_name,
+    }
+    session.add(job_score)
+    session.flush()
+    return job_score

--- a/tests/test_apify.py
+++ b/tests/test_apify.py
@@ -185,7 +185,7 @@ def test_scrape_search_run_actor_error_marks_run_failed() -> None:
 
 def test_scrape_jobs_cli_requires_apify_token(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("DATABASE_URL", f"sqlite+pysqlite:///{tmp_path / 'jobs.db'}")
-    monkeypatch.delenv("APIFY_API_TOKEN", raising=False)
+    monkeypatch.setenv("APIFY_API_TOKEN", "")
     runner = CliRunner()
 
     result = runner.invoke(app, ["scrape-jobs", "00000000-0000-0000-0000-000000000000"])

--- a/tests/test_cv_parser.py
+++ b/tests/test_cv_parser.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 from pypdf import PdfWriter
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
@@ -10,6 +11,15 @@ from typer.testing import CliRunner
 from linkedin_scrapper.cli import app
 from linkedin_scrapper.cv_parser import (
     CandidateProfileExtraction,
+    CandidateSkill,
+    ConsolidatedStack,
+    EducationItem,
+    KeyExperience,
+    Language,
+    ProfileSnapshot,
+    RemotePreference,
+    SkillContext,
+    SkillName,
     extract_cv_text,
     parse_cv,
     parse_cv_text,
@@ -21,12 +31,60 @@ from linkedin_scrapper.services.profiles import save_candidate_profile
 class StubCVParserAgent:
     def __init__(self, extraction: CandidateProfileExtraction | None = None) -> None:
         self.extraction = extraction or CandidateProfileExtraction(
+            full_name="Maxime Kets",
             target_roles=["Backend Engineer", "AI Engineer", "Data Engineer"],
-            skills=["Python", "PostgreSQL", "FastAPI", "Docker", "LangGraph"],
-            locations=["Paris", "France", "Remote"],
-            remote_preference="remote",
-            seniority="senior",
-            exclusions=["Not interested in PHP roles."],
+            locations=["Montpellier", "Occitanie", "France"],
+            total_years_of_experience=6,
+            remote_preference=[RemotePreference.FULL_REMOTE, RemotePreference.HYBRID],
+            languages_spoken=[Language.FR, Language.EN],
+            industries_experienced=["HR tech", "E-commerce"],
+            skills=[
+                CandidateSkill(
+                    name=SkillName.PYTHON,
+                    years_of_experience=6,
+                    context=SkillContext.PRODUCTION,
+                    last_used_year=2026,
+                ),
+                CandidateSkill(
+                    name=SkillName.FASTAPI,
+                    years_of_experience=3,
+                    context=SkillContext.PRODUCTION,
+                    last_used_year=2026,
+                ),
+                CandidateSkill(
+                    name=SkillName.REACT,
+                    years_of_experience=4,
+                    context=SkillContext.PRODUCTION,
+                    last_used_year=2025,
+                ),
+            ],
+            profile_snapshot=ProfileSnapshot(
+                dna="Développeur backend orienté produit et automatisation IA.",
+                current_focus="Agents IA et matching d'offres.",
+                strengths=["Python", "Architecture API", "Automatisation"],
+            ),
+            consolidated_stack=ConsolidatedStack(
+                core_backend_ai=["Python", "FastAPI", "LangGraph"],
+                core_frontend=["React", "TypeScript"],
+                infra_tools=["Docker", "PostgreSQL"],
+                business_domains=["HR tech", "E-commerce"],
+            ),
+            key_experiences=[
+                KeyExperience(
+                    title="Backend Engineer",
+                    dates="2021-2026",
+                    mission="Construire des APIs et agents IA pour automatiser des workflows.",
+                    achievements=["Déploiement d'agents LLM", "Industrialisation FastAPI"],
+                    stack=["Python", "FastAPI", "PostgreSQL"],
+                )
+            ],
+            education=[
+                EducationItem(
+                    degree="Master Informatique",
+                    school="Université de Montpellier",
+                    years="2018-2020",
+                )
+            ],
             extraction_notes=["stubbed evidence"],
         )
         self.inputs: list[Any] = []
@@ -57,31 +115,62 @@ def test_parse_cv_text_uses_agent_to_extract_structured_profile() -> None:
         agent,
     )
 
+    assert profile.full_name == "Maxime Kets"
     assert "Backend Engineer" in profile.target_roles
     assert "AI Engineer" in profile.target_roles
-    assert "Data Engineer" in profile.target_roles
-    assert {"Python", "PostgreSQL", "FastAPI", "Docker", "LangGraph"}.issubset(
-        profile.skills
-    )
-    assert {"Paris", "France", "Remote"}.issubset(profile.locations)
-    assert profile.remote_preference == "remote"
-    assert profile.seniority == "senior"
-    assert profile.exclusions == ["Not interested in PHP roles."]
-    assert profile.profile_payload["parser"] == "llm-agent-v1"
+    assert {"Montpellier", "Occitanie", "France"}.issubset(profile.locations)
+    assert profile.total_years_of_experience == 6
+    assert profile.remote_preference == [RemotePreference.FULL_REMOTE, RemotePreference.HYBRID]
+    assert profile.languages_spoken == [Language.FR, Language.EN]
+    assert profile.industries_experienced == ["HR tech", "E-commerce"]
+    assert profile.skills[0].name == SkillName.PYTHON
+    assert profile.skills[0].context == SkillContext.PRODUCTION
+    assert profile.skills[0].years_of_experience == 6
+    assert profile.skills[0].last_used_year == 2026
+    assert profile.cv_text.startswith("# Maxime Kets")
+    assert "**Localisation** : Montpellier, Occitanie, France" in profile.cv_text
+    assert "(Ouvert Remote : Oui)" in profile.cv_text
+    assert "## 🎯 Snapshot Profil (Persona)" in profile.cv_text
+    assert "## 🛠 Stack Technique Consolidée" in profile.cv_text
+    assert "### Backend Engineer | 2021-2026" in profile.cv_text
+    assert "## 🎓 Formation" in profile.cv_text
+    assert "years_of_experience" not in profile.cv_text
+    assert "last_used_year" not in profile.cv_text
+    assert profile.profile_payload["parser"] == "llm-cv-profile-v2"
     assert profile.profile_payload["extraction_notes"] == ["stubbed evidence"]
+    assert profile.profile_payload["raw_text_sha256"]
+    assert profile.profile_payload["narrative"]["full_name"] == "Maxime Kets"
     assert agent.inputs
 
 
-def test_parse_cv_prompt_keeps_locations_to_current_or_target_geography() -> None:
+def test_parse_cv_prompt_enforces_controlled_contract() -> None:
     agent = StubCVParserAgent()
 
     parse_cv_text("Based in Montpellier. Previous roles in Paris and Lyon.", agent)
 
     system_message = agent.inputs[0][0][1]
-    assert "current residence/base location" in system_message
-    assert "explicit target job-search" in system_message
-    assert "Do not include historical work" in system_message
-    assert "prefer the profile header/contact location" in system_message
+    assert "Do not infer visa status" in system_message
+    assert "FULL_REMOTE, HYBRID, or ONSITE" in system_message
+    assert "FR and EN" in system_message
+    assert "Allowed skill names" in system_message
+    assert "Python, JavaScript, TypeScript" in system_message
+    assert "do not invent new labels" in system_message
+
+
+def test_candidate_skill_rejects_values_outside_controlled_enum() -> None:
+    with pytest.raises(ValidationError):
+        CandidateProfileExtraction.model_validate(
+            {
+                "skills": [
+                    {
+                        "name": "PHP",
+                        "years_of_experience": 5,
+                        "context": "PRODUCTION",
+                        "last_used_year": 2024,
+                    }
+                ]
+            }
+        )
 
 
 def test_parse_cv_reads_text_file(tmp_path: Path) -> None:
@@ -89,17 +178,28 @@ def test_parse_cv_reads_text_file(tmp_path: Path) -> None:
     cv_path.write_text("Python Software Engineer in Berlin", encoding="utf-8")
     agent = StubCVParserAgent(
         CandidateProfileExtraction(
+            full_name="Ada Lovelace",
             target_roles=["Software Engineer"],
-            skills=["Python"],
             locations=["Berlin"],
+            total_years_of_experience=2,
+            remote_preference=[RemotePreference.HYBRID],
+            languages_spoken=[Language.EN],
+            skills=[
+                CandidateSkill(
+                    name=SkillName.PYTHON,
+                    years_of_experience=2,
+                    context=SkillContext.ACADEMIC,
+                    last_used_year=2026,
+                )
+            ],
         )
     )
 
     profile = parse_cv(cv_path, agent)
 
-    assert profile.cv_text == "Python Software Engineer in Berlin"
+    assert profile.cv_text.startswith("# Ada Lovelace")
     assert "Software Engineer" in profile.target_roles
-    assert "Python" in profile.skills
+    assert profile.skills[0].name == SkillName.PYTHON
     assert "Berlin" in profile.locations
 
 
@@ -129,8 +229,13 @@ def test_save_candidate_profile_persists_parsed_profile() -> None:
         assert profile.id == saved.id
         assert profile.cv_text == parsed_profile.cv_text
         assert profile.target_roles == parsed_profile.target_roles
-        assert profile.skills == parsed_profile.skills
         assert profile.locations == parsed_profile.locations
+        assert profile.total_years_of_experience == parsed_profile.total_years_of_experience
+        assert profile.remote_preference == ["FULL_REMOTE", "HYBRID"]
+        assert profile.languages_spoken == ["FR", "EN"]
+        assert profile.industries_experienced == ["HR tech", "E-commerce"]
+        assert profile.skills[0]["name"] == "Python"
+        assert profile.skills[0]["context"] == "PRODUCTION"
 
 
 def test_parse_cv_cli_outputs_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -144,7 +249,8 @@ def test_parse_cv_cli_outputs_profile(tmp_path: Path, monkeypatch: pytest.Monkey
     assert result.exit_code == 0
     assert "Data Engineer" in result.output
     assert "Python" in result.output
-    assert "Remote" in result.output
+    assert "FULL_REMOTE" in result.output
+    assert "# Maxime Kets" in result.output
 
 
 def test_parse_cv_cli_save_requires_database_url(tmp_path: Path, monkeypatch) -> None:
@@ -177,9 +283,10 @@ def test_parse_cv_cli_save_persists_profile(tmp_path: Path, monkeypatch) -> None
     engine = create_engine(f"sqlite+pysqlite:///{db_path}")
     with Session(engine) as session:
         profile = session.scalars(select(CandidateProfile)).one()
-        assert profile.cv_text == "Senior Python Backend Engineer in Paris"
+        assert profile.cv_text.startswith("# Maxime Kets")
         assert "Backend Engineer" in profile.target_roles
-        assert "Python" in profile.skills
+        assert profile.skills[0]["name"] == "Python"
+        assert profile.total_years_of_experience == 6
 
 
 def _patch_cli_agent(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_cv_parser.py
+++ b/tests/test_cv_parser.py
@@ -10,6 +10,8 @@ from typer.testing import CliRunner
 
 from linkedin_scrapper.cli import app
 from linkedin_scrapper.cv_parser import (
+    CV_PARSER_SYSTEM_PROMPT,
+    CV_PROFILE_EXTRACTION_SKILL_NAME,
     CandidateProfileExtraction,
     CandidateMarkdownProfile,
     CandidateSkill,
@@ -21,7 +23,9 @@ from linkedin_scrapper.cv_parser import (
     RemotePreference,
     SkillContext,
     SkillName,
+    build_cv_parser_agent,
     extract_cv_text,
+    load_skill,
     parse_cv,
     parse_cv_text,
 )
@@ -69,14 +73,6 @@ class StubCVParserAgent:
         return self.extraction
 
 
-class StubChatModel:
-    def __init__(self, agent: StubCVParserAgent) -> None:
-        self.agent = agent
-
-    def with_structured_output(self, schema: type[CandidateProfileExtraction]) -> StubCVParserAgent:
-        return self.agent
-
-
 def test_parse_cv_text_uses_agent_to_extract_structured_profile() -> None:
     agent = StubCVParserAgent()
 
@@ -120,22 +116,39 @@ def test_parse_cv_text_uses_agent_to_extract_structured_profile() -> None:
         "Développeur backend"
     )
     assert agent.inputs
+    assert agent.inputs[0]["messages"][0]["role"] == "user"
+    assert CV_PROFILE_EXTRACTION_SKILL_NAME in agent.inputs[0]["messages"][0]["content"]
 
 
-def test_parse_cv_prompt_enforces_controlled_contract() -> None:
-    agent = StubCVParserAgent()
+def test_cv_parser_contract_lives_in_load_skill_tool_not_system_prompt() -> None:
+    skill_prompt = load_skill.invoke({"skill_name": CV_PROFILE_EXTRACTION_SKILL_NAME})
 
-    parse_cv_text("Based in Montpellier. Previous roles in Paris and Lyon.", agent)
+    assert "Use load_skill when detailed domain instructions are needed" in (
+        CV_PARSER_SYSTEM_PROMPT
+    )
+    assert "Allowed skill names" not in CV_PARSER_SYSTEM_PROMPT
+    assert "Do not include a redundant skills table" not in CV_PARSER_SYSTEM_PROMPT
+    assert "Allowed skill names" in skill_prompt
+    assert "Python, JavaScript, TypeScript" in skill_prompt
+    assert "markdown_profile" in skill_prompt
+    assert "Do not include a redundant skills table" in skill_prompt
 
-    system_message = agent.inputs[0][0][1]
-    assert "Do not infer visa status" in system_message
-    assert "FULL_REMOTE, HYBRID, or ONSITE" in system_message
-    assert "FR and EN" in system_message
-    assert "Allowed skill names" in system_message
-    assert "Python, JavaScript, TypeScript" in system_message
-    assert "do not invent new labels" in system_message
-    assert "markdown_profile" in system_message
-    assert "Do not include a redundant skills table" in system_message
+
+def test_build_cv_parser_agent_uses_load_skill_tool_and_response_format(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_create_agent(**kwargs):
+        captured.update(kwargs)
+        return StubCVParserAgent()
+
+    monkeypatch.setattr("linkedin_scrapper.cv_parser.create_agent", fake_create_agent)
+
+    agent = build_cv_parser_agent(object())
+
+    assert isinstance(agent, StubCVParserAgent)
+    assert captured["tools"] == [load_skill]
+    assert captured["system_prompt"] == CV_PARSER_SYSTEM_PROMPT
+    assert captured["response_format"] is CandidateProfileExtraction
 
 
 def test_candidate_skill_rejects_values_outside_controlled_enum() -> None:
@@ -276,7 +289,11 @@ def _patch_cli_agent(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.setattr(
         "linkedin_scrapper.cli.build_cv_parser_chat_model",
-        lambda settings: StubChatModel(agent),
+        lambda settings: object(),
+    )
+    monkeypatch.setattr(
+        "linkedin_scrapper.cli.build_cv_parser_agent",
+        lambda chat_model: agent,
     )
 
 

--- a/tests/test_cv_parser.py
+++ b/tests/test_cv_parser.py
@@ -11,6 +11,7 @@ from typer.testing import CliRunner
 from linkedin_scrapper.cli import app
 from linkedin_scrapper.cv_parser import (
     CandidateProfileExtraction,
+    CandidateMarkdownProfile,
     CandidateSkill,
     ConsolidatedStack,
     EducationItem,
@@ -58,33 +59,7 @@ class StubCVParserAgent:
                     last_used_year=2025,
                 ),
             ],
-            profile_snapshot=ProfileSnapshot(
-                dna="Développeur backend orienté produit et automatisation IA.",
-                current_focus="Agents IA et matching d'offres.",
-                strengths=["Python", "Architecture API", "Automatisation"],
-            ),
-            consolidated_stack=ConsolidatedStack(
-                core_backend_ai=["Python", "FastAPI", "LangGraph"],
-                core_frontend=["React", "TypeScript"],
-                infra_tools=["Docker", "PostgreSQL"],
-                business_domains=["HR tech", "E-commerce"],
-            ),
-            key_experiences=[
-                KeyExperience(
-                    title="Backend Engineer",
-                    dates="2021-2026",
-                    mission="Construire des APIs et agents IA pour automatiser des workflows.",
-                    achievements=["Déploiement d'agents LLM", "Industrialisation FastAPI"],
-                    stack=["Python", "FastAPI", "PostgreSQL"],
-                )
-            ],
-            education=[
-                EducationItem(
-                    degree="Master Informatique",
-                    school="Université de Montpellier",
-                    years="2018-2020",
-                )
-            ],
+            markdown_profile=_markdown_profile(),
             extraction_notes=["stubbed evidence"],
         )
         self.inputs: list[Any] = []
@@ -127,6 +102,7 @@ def test_parse_cv_text_uses_agent_to_extract_structured_profile() -> None:
     assert profile.skills[0].context == SkillContext.PRODUCTION
     assert profile.skills[0].years_of_experience == 6
     assert profile.skills[0].last_used_year == 2026
+    assert profile.cv_text == agent.extraction.markdown_profile.markdown
     assert profile.cv_text.startswith("# Maxime Kets")
     assert "**Localisation** : Montpellier, Occitanie, France" in profile.cv_text
     assert "(Ouvert Remote : Oui)" in profile.cv_text
@@ -140,6 +116,9 @@ def test_parse_cv_text_uses_agent_to_extract_structured_profile() -> None:
     assert profile.profile_payload["extraction_notes"] == ["stubbed evidence"]
     assert profile.profile_payload["raw_text_sha256"]
     assert profile.profile_payload["narrative"]["full_name"] == "Maxime Kets"
+    assert profile.profile_payload["narrative"]["profile_snapshot"]["dna"].startswith(
+        "Développeur backend"
+    )
     assert agent.inputs
 
 
@@ -155,6 +134,8 @@ def test_parse_cv_prompt_enforces_controlled_contract() -> None:
     assert "Allowed skill names" in system_message
     assert "Python, JavaScript, TypeScript" in system_message
     assert "do not invent new labels" in system_message
+    assert "markdown_profile" in system_message
+    assert "Do not include a redundant skills table" in system_message
 
 
 def test_candidate_skill_rejects_values_outside_controlled_enum() -> None:
@@ -192,6 +173,7 @@ def test_parse_cv_reads_text_file(tmp_path: Path) -> None:
                     last_used_year=2026,
                 )
             ],
+            markdown_profile=CandidateMarkdownProfile(markdown="# Ada Lovelace"),
         )
     )
 
@@ -295,4 +277,73 @@ def _patch_cli_agent(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "linkedin_scrapper.cli.build_cv_parser_chat_model",
         lambda settings: StubChatModel(agent),
+    )
+
+
+def _markdown_profile() -> CandidateMarkdownProfile:
+    return CandidateMarkdownProfile(
+        profile_snapshot=ProfileSnapshot(
+            dna="Développeur backend orienté produit et automatisation IA.",
+            current_focus="Agents IA et matching d'offres.",
+            strengths=["Python", "Architecture API", "Automatisation"],
+        ),
+        consolidated_stack=ConsolidatedStack(
+            core_backend_ai=["Python", "FastAPI", "LangGraph"],
+            core_frontend=["React", "TypeScript"],
+            infra_tools=["Docker", "PostgreSQL"],
+            business_domains=["HR tech", "E-commerce"],
+        ),
+        key_experiences=[
+            KeyExperience(
+                title="Backend Engineer",
+                dates="2021-2026",
+                mission="Construire des APIs et agents IA pour automatiser des workflows.",
+                achievements=["Déploiement d'agents LLM", "Industrialisation FastAPI"],
+                stack=["Python", "FastAPI", "PostgreSQL"],
+            )
+        ],
+        education=[
+            EducationItem(
+                degree="Master Informatique",
+                school="Université de Montpellier",
+                years="2018-2020",
+            )
+        ],
+        markdown="\n".join(
+            [
+                "# Maxime Kets",
+                "",
+                "**Titre cible** : Backend Engineer, AI Engineer, Data Engineer",
+                "**Localisation** : Montpellier, Occitanie, France (Ouvert Remote : Oui)",
+                "**Langues** : FR, EN",
+                "**Expérience globale** : 6 ans",
+                "",
+                "## 🎯 Snapshot Profil (Persona)",
+                "",
+                "* **ADN** : Développeur backend orienté produit et automatisation IA.",
+                "* **Focus actuel** : Agents IA et matching d'offres.",
+                "* **Points forts** : Python, Architecture API, Automatisation",
+                "",
+                "## 🛠 Stack Technique Consolidée",
+                "",
+                "* **Core Backend & IA** : Python, FastAPI, LangGraph",
+                "* **Core Frontend** : React, TypeScript",
+                "* **Infra & Outils** : Docker, PostgreSQL",
+                "* **Domaines métiers** : HR tech, E-commerce",
+                "",
+                "## 💼 Expériences Clés Synthétisées",
+                "",
+                "### Backend Engineer | 2021-2026",
+                "",
+                "* **Mission** : Construire des APIs et agents IA pour automatiser des workflows.",
+                "* **Réalisations** :",
+                "    * Déploiement d'agents LLM",
+                "    * Industrialisation FastAPI",
+                "* **Stack** : Python, FastAPI, PostgreSQL",
+                "",
+                "## 🎓 Formation",
+                "",
+                "* Master Informatique - Université de Montpellier (2018-2020)",
+            ]
+        ),
     )

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -20,7 +20,8 @@ def test_init_db_creates_required_tables() -> None:
 
     init_db(engine)
 
-    tables = set(inspect(engine).get_table_names())
+    inspector = inspect(engine)
+    tables = set(inspector.get_table_names())
     assert {
         "candidate_profiles",
         "search_runs",
@@ -29,6 +30,16 @@ def test_init_db_creates_required_tables() -> None:
         "job_scores",
         "applications",
     }.issubset(tables)
+    candidate_profile_columns = {
+        column["name"] for column in inspector.get_columns("candidate_profiles")
+    }
+    assert {
+        "total_years_of_experience",
+        "remote_preference",
+        "languages_spoken",
+        "industries_experienced",
+        "skills",
+    }.issubset(candidate_profile_columns)
 
 
 def test_job_url_unique_constraint_deduplicates_jobs() -> None:

--- a/tests/test_job_scorer.py
+++ b/tests/test_job_scorer.py
@@ -1,0 +1,61 @@
+from typing import Any
+
+from linkedin_scrapper.job_scorer import (
+    JOB_SCORER_SYSTEM_PROMPT,
+    JobScoreExtraction,
+    score_job,
+)
+from linkedin_scrapper.models import CandidateProfile, Job
+
+
+class StubJobScorerAgent:
+    def __init__(self, extraction: JobScoreExtraction | None = None) -> None:
+        self.extraction = extraction or JobScoreExtraction(
+            score=84,
+            summary="Strong AI/full-stack match with some seniority risk.",
+            match_reasons=["AI platform focus", "Full-stack engineering alignment"],
+            missing_skills=["Large-scale ML platform experience"],
+            risk_flags=["Seniority may be high"],
+        )
+        self.inputs: list[Any] = []
+
+    def invoke(self, input: Any) -> JobScoreExtraction:
+        self.inputs.append(input)
+        return self.extraction
+
+
+def test_score_job_uses_structured_agent_and_profile_context() -> None:
+    profile = CandidateProfile(
+        cv_text="Python AI engineer",
+        target_roles=["AI Engineer"],
+        skills=["Python", "FastAPI", "RAG"],
+        locations=["Montpellier"],
+        remote_preference="remote",
+        seniority="mid",
+        exclusions=["PHP roles"],
+    )
+    job = Job(
+        title="AI Engineer",
+        company="Example",
+        location="France",
+        remote=True,
+        description="Build AI agents with Python and LLMs.",
+        url="https://www.linkedin.com/jobs/view/123",
+    )
+    agent = StubJobScorerAgent()
+
+    score = score_job(profile, job, agent)
+
+    assert score.score == 84
+    assert score.missing_skills == ["Large-scale ML platform experience"]
+    assert score.risk_flags == ["Seniority may be high"]
+    assert "Scoring guidance" in agent.inputs[0][0][1]
+    assert "Target roles: AI Engineer" in agent.inputs[0][1][1]
+    assert "Title: AI Engineer" in agent.inputs[0][1][1]
+
+
+def test_job_scorer_prompt_defines_missing_skills_and_risk_flags() -> None:
+    assert "missing_skills" in JOB_SCORER_SYSTEM_PROMPT
+    assert "important concrete skills" in JOB_SCORER_SYSTEM_PROMPT
+    assert "risk_flags" in JOB_SCORER_SYSTEM_PROMPT
+    assert "non-skill or contextual reservations" in JOB_SCORER_SYSTEM_PROMPT

--- a/tests/test_job_scorer.py
+++ b/tests/test_job_scorer.py
@@ -26,11 +26,33 @@ class StubJobScorerAgent:
 
 def test_score_job_uses_structured_agent_and_profile_context() -> None:
     profile = CandidateProfile(
-        cv_text="Python AI engineer",
+        cv_text="# Maxime Kets\n\n**Titre cible** : AI Engineer",
         target_roles=["AI Engineer"],
-        skills=["Python", "FastAPI", "RAG"],
+        total_years_of_experience=6,
+        skills=[
+            {
+                "name": "Python",
+                "years_of_experience": 6,
+                "context": "PRODUCTION",
+                "last_used_year": 2026,
+            },
+            {
+                "name": "FastAPI",
+                "years_of_experience": 3,
+                "context": "PRODUCTION",
+                "last_used_year": 2026,
+            },
+            {
+                "name": "RAG",
+                "years_of_experience": 2,
+                "context": "PERSONAL",
+                "last_used_year": 2026,
+            },
+        ],
         locations=["Montpellier"],
-        remote_preference="remote",
+        remote_preference=["FULL_REMOTE"],
+        languages_spoken=["FR", "EN"],
+        industries_experienced=["HR tech"],
         seniority="mid",
         exclusions=["PHP roles"],
     )
@@ -50,7 +72,9 @@ def test_score_job_uses_structured_agent_and_profile_context() -> None:
     assert score.missing_skills == ["Large-scale ML platform experience"]
     assert score.risk_flags == ["Seniority may be high"]
     assert "Scoring guidance" in agent.inputs[0][0][1]
+    assert "# Maxime Kets" in agent.inputs[0][1][1]
     assert "Target roles: AI Engineer" in agent.inputs[0][1][1]
+    assert "Python (6y, PRODUCTION, last used 2026)" in agent.inputs[0][1][1]
     assert "Title: AI Engineer" in agent.inputs[0][1][1]
 
 

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -43,7 +43,11 @@ def test_list_jobs_for_scoring_returns_profile_jobs_without_scores() -> None:
     with Session(engine) as session:
         profile = _create_profile_with_jobs(session, job_count=2)
         unrelated_profile = _create_profile_with_jobs(session, job_count=1)
-        scored_job = profile.search_runs[0].job_links[0].job
+        scored_job = next(
+            link.job
+            for link in profile.search_runs[0].job_links
+            if link.job.title == "Job 0"
+        )
         session.add(JobScore(job=scored_job, score=70, summary="Existing"))
         session.commit()
 
@@ -182,11 +186,27 @@ class StubChatModel:
 def _create_profile_with_jobs(session: Session, job_count: int) -> CandidateProfile:
     profile_token = str(uuid4())
     profile = CandidateProfile(
-        cv_text="Python AI engineer",
+        cv_text="# Maxime Kets\n\n**Titre cible** : AI Engineer",
         target_roles=["AI Engineer"],
-        skills=["Python", "FastAPI"],
+        total_years_of_experience=6,
+        skills=[
+            {
+                "name": "Python",
+                "years_of_experience": 6,
+                "context": "PRODUCTION",
+                "last_used_year": 2026,
+            },
+            {
+                "name": "FastAPI",
+                "years_of_experience": 3,
+                "context": "PRODUCTION",
+                "last_used_year": 2026,
+            },
+        ],
         locations=["France"],
-        remote_preference="remote",
+        remote_preference=["FULL_REMOTE"],
+        languages_spoken=["FR", "EN"],
+        industries_experienced=["HR tech"],
         seniority="mid",
     )
     search_run = SearchRun(

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -1,0 +1,219 @@
+from uuid import uuid4
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+from typer.testing import CliRunner
+
+from linkedin_scrapper.cli import app
+from linkedin_scrapper.job_scorer import JobScoreExtraction
+from linkedin_scrapper.models import (
+    Base,
+    CandidateProfile,
+    Job,
+    JobScore,
+    SearchRun,
+    SearchRunJob,
+)
+from linkedin_scrapper.services.scores import (
+    list_jobs_for_scoring,
+    score_jobs_for_profile,
+)
+
+
+class StubJobScorerAgent:
+    def __init__(self, score: int = 82) -> None:
+        self.score = score
+        self.calls = []
+
+    def invoke(self, input):
+        self.calls.append(input)
+        return JobScoreExtraction(
+            score=self.score,
+            summary=f"Score {self.score}",
+            match_reasons=["Role aligns"],
+            missing_skills=["Kubernetes"],
+            risk_flags=["Seniority unclear"],
+        )
+
+
+def test_list_jobs_for_scoring_returns_profile_jobs_without_scores() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        profile = _create_profile_with_jobs(session, job_count=2)
+        unrelated_profile = _create_profile_with_jobs(session, job_count=1)
+        scored_job = profile.search_runs[0].job_links[0].job
+        session.add(JobScore(job=scored_job, score=70, summary="Existing"))
+        session.commit()
+
+        jobs = list_jobs_for_scoring(session, profile)
+        unrelated_jobs = list_jobs_for_scoring(session, unrelated_profile)
+
+        assert len(jobs) == 1
+        assert jobs[0].title == "Job 1"
+        assert len(unrelated_jobs) == 1
+        assert unrelated_jobs[0].title == "Job 0"
+
+
+def test_score_jobs_for_profile_persists_scores() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        profile = _create_profile_with_jobs(session, job_count=1)
+        job = list_jobs_for_scoring(session, profile)[0]
+
+        results = score_jobs_for_profile(
+            session=session,
+            profile=profile,
+            jobs=[job],
+            agent=StubJobScorerAgent(score=88),
+            model_name="gpt-test",
+        )
+
+        saved_score = session.scalars(select(JobScore)).one()
+        assert results[0].score == 88
+        assert saved_score.score == 88
+        assert saved_score.summary == "Score 88"
+        assert saved_score.match_reasons == ["Role aligns"]
+        assert saved_score.missing_skills == ["Kubernetes"]
+        assert saved_score.risk_flags == ["Seniority unclear"]
+        assert saved_score.scoring_payload["model"] == "gpt-test"
+        assert saved_score.scoring_payload["profile_id"] == str(profile.id)
+
+
+def test_score_jobs_skips_existing_scores_unless_rescore() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        profile = _create_profile_with_jobs(session, job_count=1)
+        job = profile.search_runs[0].job_links[0].job
+        session.add(JobScore(job=job, score=60, summary="Existing"))
+        session.commit()
+        agent = StubJobScorerAgent(score=90)
+
+        skipped = score_jobs_for_profile(
+            session=session,
+            profile=profile,
+            jobs=[job],
+            agent=agent,
+            model_name="gpt-test",
+        )
+        rescored = score_jobs_for_profile(
+            session=session,
+            profile=profile,
+            jobs=[job],
+            agent=agent,
+            model_name="gpt-test",
+            rescore=True,
+        )
+
+        saved_score = session.scalars(select(JobScore)).one()
+        assert skipped[0].skipped is True
+        assert skipped[0].score == 60
+        assert len(agent.calls) == 1
+        assert rescored[0].skipped is False
+        assert saved_score.score == 90
+
+
+def test_list_jobs_for_scoring_honors_limit_and_include_scored() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        profile = _create_profile_with_jobs(session, job_count=3)
+        session.add(JobScore(job=profile.search_runs[0].job_links[0].job, score=75))
+        session.commit()
+
+        unscored = list_jobs_for_scoring(session, profile, limit=1)
+        all_jobs = list_jobs_for_scoring(session, profile, limit=3, include_scored=True)
+
+        assert len(unscored) == 1
+        assert len(all_jobs) == 3
+
+
+def test_score_jobs_cli_requires_openai_key(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+pysqlite:///{tmp_path / 'scores.db'}")
+    monkeypatch.setenv("OPENAI_API_KEY", "")
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["score-jobs", "00000000-0000-0000-0000-000000000000"])
+
+    assert result.exit_code == 1
+    assert "OPENAI_API_KEY" in result.output
+
+
+def test_score_jobs_cli_scores_limited_jobs(tmp_path, monkeypatch) -> None:
+    db_path = tmp_path / "scores.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+pysqlite:///{db_path}")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(
+        "linkedin_scrapper.cli.build_chat_model",
+        lambda settings: StubChatModel(StubJobScorerAgent(score=91)),
+    )
+    runner = CliRunner()
+
+    init_result = runner.invoke(app, ["init-db"])
+    profile_id = _insert_profile_with_jobs(db_path, job_count=2)
+    result = runner.invoke(app, ["score-jobs", str(profile_id), "--limit-jobs", "1"])
+
+    assert init_result.exit_code == 0
+    assert result.exit_code == 0
+    assert "jobs_selected" in result.output
+    assert "scores_created" in result.output
+
+    engine = create_engine(f"sqlite+pysqlite:///{db_path}")
+    with Session(engine) as session:
+        scores = session.scalars(select(JobScore)).all()
+        assert len(scores) == 1
+        assert scores[0].score == 91
+
+
+class StubChatModel:
+    def __init__(self, agent: StubJobScorerAgent) -> None:
+        self.agent = agent
+
+    def with_structured_output(self, schema):
+        return self.agent
+
+
+def _create_profile_with_jobs(session: Session, job_count: int) -> CandidateProfile:
+    profile_token = str(uuid4())
+    profile = CandidateProfile(
+        cv_text="Python AI engineer",
+        target_roles=["AI Engineer"],
+        skills=["Python", "FastAPI"],
+        locations=["France"],
+        remote_preference="remote",
+        seniority="mid",
+    )
+    search_run = SearchRun(
+        candidate_profile=profile,
+        query="AI Engineer",
+        linkedin_url="https://www.linkedin.com/jobs/search/?keywords=AI+Engineer",
+        actor_name="curious_coder/linkedin-jobs-scraper",
+    )
+    for index in range(job_count):
+        search_run.job_links.append(
+            SearchRunJob(
+                job=Job(
+                    title=f"Job {index}",
+                    company="Example",
+                    url=f"https://www.linkedin.com/jobs/view/{profile_token}-{index}",
+                    description="Build AI tools with Python.",
+                )
+            )
+        )
+    session.add(search_run)
+    session.commit()
+    session.refresh(profile)
+    return profile
+
+
+def _insert_profile_with_jobs(db_path, job_count: int):
+    engine = create_engine(f"sqlite+pysqlite:///{db_path}")
+    with Session(engine) as session:
+        profile = _create_profile_with_jobs(session, job_count)
+        return profile.id

--- a/tests/test_search_planner.py
+++ b/tests/test_search_planner.py
@@ -6,6 +6,7 @@ from typer.testing import CliRunner
 
 from linkedin_scrapper.cli import app
 from linkedin_scrapper.cv_parser import (
+    CandidateMarkdownProfile,
     CandidateSkill,
     Language,
     ParsedCandidateProfile,
@@ -183,6 +184,9 @@ def test_generate_linkedin_searches_accepts_parsed_profile() -> None:
         remote_preference=[RemotePreference.FULL_REMOTE],
         languages_spoken=[Language.FR, Language.EN],
         industries_experienced=["HR tech"],
+        markdown_profile=CandidateMarkdownProfile(
+            markdown="# Maxime Kets\n\n**Titre cible** : Backend Engineer, Data Engineer"
+        ),
         seniority="senior",
     )
 

--- a/tests/test_search_planner.py
+++ b/tests/test_search_planner.py
@@ -5,7 +5,14 @@ from sqlalchemy.orm import Session
 from typer.testing import CliRunner
 
 from linkedin_scrapper.cli import app
-from linkedin_scrapper.cv_parser import ParsedCandidateProfile
+from linkedin_scrapper.cv_parser import (
+    CandidateSkill,
+    Language,
+    ParsedCandidateProfile,
+    RemotePreference,
+    SkillContext,
+    SkillName,
+)
 from linkedin_scrapper.models import Base, CandidateProfile, SearchRun, SearchRunStatus
 from linkedin_scrapper.search_planner import (
     LinkedInSearchPlan,
@@ -147,15 +154,35 @@ def test_generate_linkedin_searches_returns_two_urls_per_limited_deduped_title()
     assert "f_WT=2" in searches[1].linkedin_url
     assert agent.inputs
     assert "Maximum job titles: 5" in agent.inputs[0][1][1]
+    assert "Candidate markdown context:" in agent.inputs[0][1][1]
+    assert "# Maxime Kets" in agent.inputs[0][1][1]
+    assert "Python (6y, PRODUCTION, last used 2026)" in agent.inputs[0][1][1]
 
 
 def test_generate_linkedin_searches_accepts_parsed_profile() -> None:
     profile = ParsedCandidateProfile(
-        cv_text="Senior Python backend engineer in Paris",
+        cv_text="# Maxime Kets\n\n**Titre cible** : Backend Engineer, Data Engineer",
+        full_name="Maxime Kets",
         target_roles=["Backend Engineer", "Data Engineer"],
-        skills=["Python", "PostgreSQL"],
+        total_years_of_experience=6,
+        skills=[
+            CandidateSkill(
+                name=SkillName.PYTHON,
+                years_of_experience=6,
+                context=SkillContext.PRODUCTION,
+                last_used_year=2026,
+            ),
+            CandidateSkill(
+                name=SkillName.POSTGRESQL,
+                years_of_experience=4,
+                context=SkillContext.PRODUCTION,
+                last_used_year=2026,
+            ),
+        ],
         locations=["Paris", "Remote"],
-        remote_preference="remote",
+        remote_preference=[RemotePreference.FULL_REMOTE],
+        languages_spoken=[Language.FR, Language.EN],
+        industries_experienced=["HR tech"],
         seniority="senior",
     )
 
@@ -251,11 +278,39 @@ def test_generate_searches_cli_saves_search_runs(tmp_path, monkeypatch) -> None:
 
 def _candidate_profile() -> CandidateProfile:
     return CandidateProfile(
-        cv_text="Senior Python backend engineer in Paris",
+        cv_text="# Maxime Kets\n\n**Titre cible** : Backend Engineer, Data Engineer",
         target_roles=["Backend Engineer", "Data Engineer", "AI Engineer"],
-        skills=["Python", "PostgreSQL", "LangChain", "Docker"],
+        total_years_of_experience=6,
+        skills=[
+            {
+                "name": "Python",
+                "years_of_experience": 6,
+                "context": "PRODUCTION",
+                "last_used_year": 2026,
+            },
+            {
+                "name": "PostgreSQL",
+                "years_of_experience": 4,
+                "context": "PRODUCTION",
+                "last_used_year": 2026,
+            },
+            {
+                "name": "LangChain",
+                "years_of_experience": 2,
+                "context": "PERSONAL",
+                "last_used_year": 2025,
+            },
+            {
+                "name": "Docker",
+                "years_of_experience": 4,
+                "context": "PRODUCTION",
+                "last_used_year": 2026,
+            },
+        ],
         locations=["Paris", "France", "Remote"],
-        remote_preference="remote",
+        remote_preference=["FULL_REMOTE"],
+        languages_spoken=["FR", "EN"],
+        industries_experienced=["HR tech"],
         seniority="senior",
         exclusions=["PHP roles"],
     )


### PR DESCRIPTION
## Summary
- Add a structured LLM job scorer for persisted LinkedIn jobs.
- Persist scores, summaries, match reasons, missing skills, and risk flags in `job_scores`.
- Add `score-jobs PROFILE_ID --limit-jobs 20` with optional `--rescore`.
- Skip already scored jobs by default to control cost.
- Add tests for scoring prompts, persistence, skipping/rescoring, profile scoping, and CLI behavior.

## Validation
- `PYTHONPATH=src ./.venv/bin/pytest`
- `./.venv/bin/ruff check .`
- `PYTHONPATH=src ./.venv/bin/python -m compileall main.py src tests`

Closes #8